### PR TITLE
Add working github workflow to rewrite branch, builds libusbhsfs + nxdt rewrite

### DIFF
--- a/.github/workflows/rewrite.yml
+++ b/.github/workflows/rewrite.yml
@@ -1,0 +1,57 @@
+name: Build nxdumptool 'rewrite' tests
+
+on:
+  push:
+    branches: [ rewrite ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: devkitpro/devkita64
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Updating repos, install dkp-toolchain-vars, and set permissions...
+        run: |
+          sudo apt-get update ; sudo apt-get upgrade -y patch fakeroot p7zip-full
+          sudo -n dkp-pacman --noconfirm -U $GITHUB_WORKSPACE/libs/dkp-toolchain-vars/dkp-toolchain-vars-1.0.0-2-any.pkg.tar.xz
+          useradd nxdt-build
+          chmod 777 -R $GITHUB_WORKSPACE
+
+      - name: Export variables.
+        run: |
+          export COMMIT="$(git rev-parse --short HEAD)" ; echo commit="$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+      - name: Building libusbhsfs - liblwext4...
+        run: |
+          cd $GITHUB_WORKSPACE/libs/libusbhsfs/liblwext4
+          sudo -u nxdt-build -n COMMIT="$(git rev-parse --short HEAD)" DEVKITPRO=/opt/devkitpro DEVKITARM=/opt/devkitpro/devkitARM DEVKITPPC=/opt/devkitpro/devkitPPC dkp-makepkg
+          sudo dkp-pacman -U switch-lwext4*.tar.xz --noconfirm
+
+      - name: Building libusbhsfs - libntfs-3g...
+        run: |
+          cd $GITHUB_WORKSPACE/libs/libusbhsfs/libntfs-3g
+          sudo -u nxdt-build -n COMMIT="$(git rev-parse --short HEAD)" DEVKITPRO=/opt/devkitpro DEVKITARM=/opt/devkitpro/devkitARM DEVKITPPC=/opt/devkitpro/devkitPPC dkp-makepkg
+          sudo dkp-pacman -U switch-libntfs-3g*.tar.xz --noconfirm
+
+      - name: Building nxdumptool...
+        run: |
+          cd $GITHUB_WORKSPACE
+          ./build.sh
+
+      - uses: actions/upload-artifact@v2.3.1
+        with:
+          name: nxdumptool rewrite (NRO) - ${{ env.commit }}.7z
+          path: nxdumptool-rewrite_poc_${{ env.commit }}.7z
+          if-no-files-found: error
+
+      - uses: actions/upload-artifact@v2.3.1
+        with:
+          name: nxdumptool rewrite - (Debug ELF) - ${{ env.commit }}.7z
+          path: nxdumptool-rewrite_poc_${{ env.commit }}-Debug_ELFs.7z
+          if-no-files-found: error

--- a/.github/workflows/rewrite.yml
+++ b/.github/workflows/rewrite.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Updating repos, install dkp-toolchain-vars, and set permissions...
         run: |
           sudo apt-get update ; sudo apt-get upgrade -y patch fakeroot p7zip-full
-          sudo -n dkp-pacman --noconfirm -U "https://wii.leseratte10.de/devkitPro/other-stuff/dkp-toolchain-vars-1.0.0-2-any.pkg.tar.xz"
+          sudo -n dkp-pacman --noconfirm -U "https://web.archive.org/web/20220209041425if_/https://wii.leseratte10.de/devkitPro/other-stuff/dkp-toolchain-vars-1.0.0-2-any.pkg.tar.xz"
           useradd nxdt-build
           chmod 777 -R $GITHUB_WORKSPACE
 

--- a/.github/workflows/rewrite.yml
+++ b/.github/workflows/rewrite.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Updating repos, install dkp-toolchain-vars, and set permissions...
         run: |
           sudo apt-get update ; sudo apt-get upgrade -y patch fakeroot p7zip-full
-          sudo -n dkp-pacman --noconfirm -U $GITHUB_WORKSPACE/libs/dkp-toolchain-vars/dkp-toolchain-vars-1.0.0-2-any.pkg.tar.xz
+          sudo -n dkp-pacman --noconfirm -U "https://wii.leseratte10.de/devkitPro/other-stuff/dkp-toolchain-vars-1.0.0-2-any.pkg.tar.xz"
           useradd nxdt-build
           chmod 777 -R $GITHUB_WORKSPACE
 

--- a/build.sh
+++ b/build.sh
@@ -48,5 +48,3 @@ cd ../..
 rm -f ./source/main.c
 rm -rf ./code_templates/tmp
 mv ./main.cpp ./source/main.cpp
-
-read -p "Press any key to finish ..."


### PR DESCRIPTION
Add a working github workflow to `rewrite` branch, which lets new commits build automatically on commit push. 
Open to possible edits as you feel fit.

-----

Edit:

Only issues I forsee at the moment is that these don't automatically get pushed to the releases section of the repo (which can be done later), and the more important issue of GHA storage/build times.
Might be good to set a $0 USD spending limit so you don't have to worry about that?

> | Product | Storage | Minutes (per month) |
> -- | -- | --
> | GitHub Free | 500 MB | 2,000 

Info source on table contents:
Account limits: https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#included-storage-and-minutes
Setting spending limits: https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#about-spending-limits

-----

How to see current usage from Github's user settings is mentioned [HERE](https://github.community/t/managing-actions-storage-space/16973/11) (links to "Github Community" forums)
> You can use “Get usage report” option in billing section, it shows daily usage stats for each repo you have including storage usage

Said page to get the button can be found at https://github.com/settings/billing
After hitting the length of time you want to look through, you'll get an email with the actual report., or it's seemingly also available under the button which seems to be the same info?)

