### PR TITLE
Workflow improvement

### DIFF
--- a/.github/workflows/rewrite.yml
+++ b/.github/workflows/rewrite.yml
@@ -106,3 +106,22 @@ jobs:
       #    name: nxdumptool-rewrite-${{ env.nxdt_commit }}-WIP_UI.elf
       #    path: nxdumptool/nxdumptool.elf
       #    if-no-files-found: error
+
+      - name: Upload artifact to prerelease
+        uses: ncipollo/release-action@v1
+        with:
+          # only update on prerelease
+          prerelease: True
+          tag: "rewrite-prerelease"
+          updateOnlyUnreleased: True
+          # remove old artifacts & replace with new ones
+          removeArtifacts: True
+          replacesArtifacts: True
+          # update preference
+          allowUpdates: True
+          omitBody: True
+          omitBodyDuringUpdate: True
+          omitNameDuringUpdate: True
+          artifacts: "nxdumptool/code_templates/tmp/nxdt_rw_poc.*"
+          #artifacts: "nxdumptool/code_templates/tmp/nxdt_rw_poc.*, nxdumptool/nxdumptool.*"
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rewrite.yml
+++ b/.github/workflows/rewrite.yml
@@ -24,6 +24,8 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Skip build with [ci skip] in commit
+    if: "! contains(github.event.head_commit.message, '[ci skip]')"
     container:
       image: devkitpro/devkita64
     steps:


### PR DESCRIPTION
I think the commit messages tell everything, but still put an explanation here:
- 1ad81d11a352d8faaf4cfa906e901985d5dcd94d adds the ability to skip ci with commit message including `[ci skip]` (e.g. `workflow: make a change [ci skip]`), you can change the hint words anyway.
- c7b80b6699620c56c33589057f61f5d1e9aa909c uploads artifacts to prerelease, or more specifically the `rewrite-prerelease` tag.

Workflow artifacts require login to download and I acknowledge that currently there is a workaround via https://nightly.link. I just think that you may want to have a native solution too. And users can still get artifacts generated by old commits via nightly.link afterwards.

A side note about the upload: files are uploaded _as is_ (e.g. `nxdt_rw_poc.nro` & `nxdt_rw_poc.elf`) as I do not rename them with a commit hash suffix. This way you can have the same download URL for latest nro and thus skip a redirect on nightly.link. If you want to change that, you can check [release-action documentation](https://github.com/ncipollo/release-action#action-inputs), notably `body` and `bodyFile`.

Edit: fix typo and add example.