### PR TITLE
Support host script on Python 3.9

### DIFF
--- a/host/nxdt_host.py
+++ b/host/nxdt_host.py
@@ -32,7 +32,7 @@
 # Under MacOS, use `brew install libusb` to install libusb via Homebrew.
 # Under Linux, you should be good to go from the start. If not, just use the package manager from your distro to install libusb.
 
-from __future__ import print_function
+from __future__ import annotations
 
 import sys
 import os


### PR DESCRIPTION
The host script can’t run on Python 3.9 because of [PEP 604][pep]-style annotations. Adding a future import can fix this. The `print_function` import is being removed since it is unnecessary on all releases of Python 3.

[pep]: https://peps.python.org/pep-0604/