### PR TITLE
Minor workflow simplifications

### DIFF
--- a/.github/workflows/rewrite.yml
+++ b/.github/workflows/rewrite.yml
@@ -16,66 +16,50 @@ on:
   # Allows you to run this workflow manually from the Actions tab.
   workflow_dispatch:
 
-env:
-  DEVKITPRO: "/opt/devkitpro"
-  DEVKITARM: "/opt/devkitpro/devkitARM"
-  DEVKITPPC: "/opt/devkitpro/devkitPPC"
-
 jobs:
   build:
     runs-on: ubuntu-latest
-    # Skip build with [ci skip] in commit
-    if: "! contains(github.event.head_commit.message, '[ci skip]')"
     container:
       image: devkitpro/devkita64
     steps:
       # Workaround: avoid requesting data from devkitPro servers because they ban most CI/CD scripts.
+      # TODO: Remove the last dkp-pacman invocation if https://github.com/devkitPro/docker/pull/28 gets accepted
       - name: Update packages
         run: |
           sudo -n apt-get update
           sudo -n apt-get upgrade -y patch autoconf automake tar bzip2 diffutils pkgconf fakeroot git file zstd
           sudo -n dkp-pacman --noconfirm -U \
-            "https://wii.leseratte10.de/devkitPro/other-stuff/dkp-toolchain-vars-1.0.3-2-any.pkg.tar.zst" \
-            "https://wii.leseratte10.de/devkitPro/cmake/switch-cmake-1.5.0-1-any.pkg.tar.xz"
-        #    "https://wii.leseratte10.de/devkitPro/switch/switch-libjson-c-0.16-1-any.pkg.tar.xz" \
-        #    "https://wii.leseratte10.de/devkitPro/switch/switch-libpng-1.6.39-2-any.pkg.tar.zst" \
-        #    "https://wii.leseratte10.de/devkitPro/switch/switch-zlib-1.2.13-1-any.pkg.tar.xz"
+            "https://wii.leseratte10.de/devkitPro/other-stuff/dkp-toolchain-vars-1.0.3-2-any.pkg.tar.zst"
 
-      - name: Silence all git safe directory warnings
-        run: git config --system --add safe.directory '*'
-
-      # Workaround: manually use git instead of actions/checkout to parse repository properties (e.g. branch name, commit hash, etc.) on our own.
-      - name: Checkout latest nxdumptool-rewrite commit
-        run: |
-          cd "$GITHUB_WORKSPACE"
-          git clone --branch rewrite --recurse-submodules https://github.com/DarkMatterCore/nxdumptool.git
+      - uses: actions/checkout@v4
+        with:
+          path: nxdumptool
+          submodules: recursive
 
       - name: Checkout latest libnx commit
-        run: |
-          cd "$GITHUB_WORKSPACE"
-          git clone --recurse-submodules https://github.com/switchbrew/libnx.git
+        uses: actions/checkout@v4
+        with:
+          repository: switchbrew/libnx
+          path: libnx
+          submodules: recursive
 
       - name: Set workspace permissions
         run: chmod 777 -R "$GITHUB_WORKSPACE"
 
       - name: Build and install libnx
+        working-directory: libnx
         run: |
-          cd "$GITHUB_WORKSPACE/libnx"
           make install -j$(nproc)
 
-      # Workaround: dkp-makepkg's "-i" option fails because it tries to run pacman as root on its own using sudo, and a password must be interactively provided.
-      # We can't just provide root access to dkp-makepkg because it refuses to work at all if we do so.
-      # As much as I'd like to run "make fs-libs" and call it a day, it's just not possible.
       - name: Build libusbhsfs dependencies
+        working-directory: nxdumptool/libs/libusbhsfs
         run: |
-          cd "$GITHUB_WORKSPACE/nxdumptool/libs/libusbhsfs"
-          cd libntfs-3g; su -s /bin/bash nobody -c "dkp-makepkg -c -C -f" > /dev/null; sudo -n dkp-pacman -U --needed --noconfirm *.pkg.tar.* > /dev/null; cd ..
-          cd liblwext4; su -s /bin/bash nobody -c "dkp-makepkg -c -C -f" > /dev/null; sudo -n dkp-pacman -U --needed --noconfirm *.pkg.tar.* > /dev/null; cd ..
+          make fs-libs
 
       - name: Build nxdumptool-rewrite PoC binary
+        working-directory: nxdumptool
         run: |
-          cd "$GITHUB_WORKSPACE/nxdumptool"
-          echo "nxdt_commit=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          echo "nxdt_commit=$(git rev-parse --short ${{ github.sha }})" >> $GITHUB_ENV
           ./build.sh
 
       #- name: Build nxdumptool-rewrite GUI binary


### PR DESCRIPTION
This PR is a follow up from DarkMatterCore/libusbhsfs#29 and simplifies the existing workflow a tiny bit.

I told you about some improvements quite a while ago and never got around to PR them. It seems someone else also found improvements, so the changes I made aren't as significant.

Some notes about the changes I made:
- The check to skip a workflow run can be omitted, since this can already be done without that.
  See: [Skipping workflow runs](https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs)
- Earlier I also opened a PR for the docker images from dkp (https://github.com/devkitPro/docker/pull/28) to include the `dkp-toolchain-vars` package as well.
  If that PR gets accepted the last dkp-pacman line can also be removed which I'll do in a new PR.

A few other improvements that could be made, but I didn't want to include here:
- Using ccache with GitHub Actions cache to speed up compilations (like [ldn_mitm](https://github.com/spacemeowx2/ldn_mitm/blob/148116eceb3bd3bfc0cf9ca11c5ca5e83aac43fe/.github/workflows/release.yml#L27-L33))
- Using releases for libusbhsfs and installing them in the workflow instead of compiling it there
- Using the libnx library that's already present in the dkp image and falling back to the latest commit if the first build attempt fails (similar to [ldn_mitm](https://github.com/spacemeowx2/ldn_mitm/blob/148116eceb3bd3bfc0cf9ca11c5ca5e83aac43fe/.github/workflows/release.yml#L35-L44))

Workflow run using my libusbhsfs changes: https://github.com/TSRBerry/nxdumptool/actions/runs/6709816685/job/18233685461
Although it fails in the end this seems to be unrelated to my changes.
