### PR TITLE
Support for >260 char filenames on Windows

### DIFF
--- a/host/nxdt_host.py
+++ b/host/nxdt_host.py
@@ -787,6 +787,10 @@ def usbHandleSendFileProperties(cmd_block: bytes) -> int | None:
         # Generate full, absolute path to the destination file.
         fullpath = os.path.abspath(g_outputDir + os.path.sep + filename)
 
+        # Unconditionally enable 32-bit paths on Windows.
+        if g_isWindows:
+           fullpath = '\\\\?\\' + fullpath.replace("/", "\\")
+
         # Get parent directory path.
         dirpath = os.path.dirname(fullpath)
 
@@ -822,6 +826,11 @@ def usbHandleSendFileProperties(cmd_block: bytes) -> int | None:
         # Retrieve what we need using global variables.
         file = g_nspFile
         fullpath = g_nspFilePath
+        
+        # Unconditionally enable 32-bit paths on Windows.
+        if g_isWindows:
+           fullpath = '\\\\?\\' + fullpath.replace("/", "\\")
+
         dirpath = os.path.dirname(fullpath)
 
     # Check if we're dealing with an empty file or with the first SendFileProperties command from a NSP.


### PR DESCRIPTION
Yesterday I had trouble dumping a cartridge with a very long filename, itself longer than the 260 character limit of Windows using standard pathnames and APIs (before even considering how deep or long the output directory was):

`The following is 264 characters long by itself:`
`/Gamecard/FINAL FANTASY [01000EA014150000][v0] + FINAL FANTASY III [01002E2014158000][v0] + FINAL FANTASY IV 1.0.1 [01004B301415A000][v65536] + FINAL FANTASY II [01006B7014156000][v0] + FINAL FANTASY VI 1.0.1 [0100AA001415E000][v65536] + FINAL FAN [KA][NC][NT].xci`

This immediately fails, with `usbHandleSetFileProperties()` just hanging. The filename can be truncated before being set, however, it's clear that it already is for some other reason (Final Fantasy V is rendered above as merely FINAL FAN). And of course, this wouldn't help if the output directory is already somewhere rather deep. Fortunately there is a workaround: Windows isn't actually limited to 260 character path lengths, but Windows' default APIs seem to be. An alternative syntax that prepends `\\?\` to 'proper' Windows paths (so using backslashes throughout instead of slashes as the separator) will trigger the codepath necessary to exceed the maximum path length limitation. [See here for more info on this](https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file?redirectedfrom=MSDN#win32-file-namespaces); apparently this also disables all string parsing, but if this has any negative effect I haven't come across it.

In any case, I've tested this with Python `3.11.6` and `3.12.0` under Windows 11 and...it worked fine!

I've also added an extra unconditional conversion of all forward-slashes to backslashes as well in order to accommodate compatibility with Python running under msys2, because the default separator under that is a forward slash, which will error out as an invalid path. This works under `msys2/mingw64`, `msys2/ucrt64`, and `msys2/clang64`.

I have /not/ tested this with Cygwin as I don't use it, but would also hope that it doesn't represent itself as Windows to `platform.system()`'s check. If that's a problem I can try to make time for it, but this will solve this issue for most users, particularly on Windows, where they'll most likely be using the packaged version. (I have also tested this, and it worked fine as expected, though not on a separate machine. I had some trouble creating a valid package at first, but as you do not seem to have the same issue I would rather discuss it first/separately). I also have not tested these changes on *nix, BSD, Mac, or anything else, but unless any of those systems represent themselves as Windows to `platform.system()` I don't anticipate that being an issue.

Anyway, hopefully this is acceptable, there really isn't much going on here and what I did was pretty straightforward, but if not/if you need anything else, let me know. I did save the logs and take a few screenshots along the way but have no other proof; that said it shouldn't be too difficult to verify it works. 