### PR TITLE
Quality-of-Life 0: Logging (log-to-file, color in cli, formatting, other minor changes)

### DIFF
--- a/host/nxdt_host.py
+++ b/host/nxdt_host.py
@@ -1226,7 +1226,7 @@ def usbHandleStartExtractedFsDump(cmd_block: bytes) -> int:
                 g_logger.info(f'\nSrc:\t{path_array[4]}')
                 g_logger.info(f'\t{path_array[5]}, FS section #{path_array[6]}')
             case _: 
-                g__logger.info(f'\tExtracted FS dump from novel source (???) started!')
+                g_logger.info(f'\tExtracted FS dump from novel source (???) started!')
                 g_logger.info:(f'\nRoot:\t{extracted_fs_root_path}')
         g_logger.info(f'Size:\t{g_formattedFileSize:.2f} {g_formattedFileUnit}')
         g_logger.info(f'Files:')

--- a/host/nxdt_host.py
+++ b/host/nxdt_host.py
@@ -321,8 +321,8 @@ g_outputDir: str = ''
 g_logPath: str = ''
 g_pathSep: str = ''
 
-g_logLevelIntVar: Optional[tk.IntVar] = None
-g_logToFileBoolVar: Optional[tk.BooleanVar] = None
+g_logLevelIntVar: tk.IntVar | None = None
+g_logToFileBoolVar: tk.BooleanVar | None = None
 g_osType: str = ''
 g_osVersion: str = ''
 
@@ -367,7 +367,6 @@ g_nspFile: Optional[BufferedWriter] = None
 g_nspFilePath: str = ''
 
 g_extractedFsDumpMode: bool = False
-g_layeredFsDumpMode: bool = False
 
 g_formattedFileSize: float = 0
 g_fileSizeMiB: float = 0

--- a/host/nxdt_host.py
+++ b/host/nxdt_host.py
@@ -434,7 +434,7 @@ class LogQueueHandler(logging.Handler):
 
 # Reference: https://beenje.github.io/blog/posts/logging-to-a-tkinter-scrolledtext-widget.
 class LogConsole:
-    def __init__(self, scrolled_text: Optional[scrolledtext.ScrolledText] = None):
+    def __init__(self, scrolled_text: scrolledtext.ScrolledText | None = None) -> None:
         assert g_logger is not None
 
         self.scrolled_text = scrolled_text
@@ -838,7 +838,6 @@ def usbGetDeviceEndpoints() -> bool:
     return True
 
 def usbRead(size: int, timeout: int = -1) -> bytes:
-
     rd = b''
 
     try:
@@ -848,12 +847,11 @@ def usbRead(size: int, timeout: int = -1) -> bytes:
         if not g_cliMode:
             utilsLogException(traceback.format_exc())
         if g_logger is not None:
-            g_logger.error('\nUSB timeout triggered or console disconnected.\n')
+            g_logger.error('\nUSB timeout triggered or console disconnected.')
 
     return rd
 
 def usbWrite(data: bytes, timeout: int = -1) -> int:
-
     wr = 0
 
     try:
@@ -862,7 +860,7 @@ def usbWrite(data: bytes, timeout: int = -1) -> int:
         if not g_cliMode:
             utilsLogException(traceback.format_exc())
         if g_logger is not None:
-            g_logger.error('\nUSB timeout triggered or console disconnected.\n')
+            g_logger.error('\nUSB timeout triggered or console disconnected.')
 
     return wr
 
@@ -875,6 +873,9 @@ def usbHandleStartSession(cmd_block: bytes) -> int:
 
     assert g_logger is not None
 
+    if g_cliMode:
+        print()
+        
     g_logger.debug(f'\nReceived StartSession ({USB_CMD_START_SESSION:02X}) command.')
 
     # Parse command block.
@@ -1064,7 +1065,7 @@ def usbHandleSendFileProperties(cmd_block: bytes) -> int | None:
         
         dirpath = os.path.dirname(fullpath)
         printable_fullpath = (fullpath[4:] if g_isWindows else fullpath)
-        
+
     # Check if we're dealing with an empty file or with the first SendFileProperties command from a NSP.
     if (not file_size) or (g_nspTransferMode and file_size == g_nspSize):
         # Close file (if needed).
@@ -1253,14 +1254,14 @@ def usbHandleSendNspHeader(cmd_block: bytes) -> int:
 
 def usbHandleEndSession(cmd_block: bytes) -> int:
     assert g_logger is not None
-    g_logger.debug(f'\nReceived EndSession ({USB_CMD_END_SESSION:02X}) command.')
+    g_logger.debug(f'Received EndSession ({USB_CMD_END_SESSION:02X}) command.')
     return USB_STATUS_SUCCESS
 
 def usbHandleStartExtractedFsDump(cmd_block: bytes) -> int:
     assert g_logger is not None
     global g_isWindows, g_outputDir, g_extractedFsDumpMode, g_extractedFsAbsRoot, g_formattedFileSize, g_formattedFileUnit, g_fileSizeMiB, g_startTime
      
-    g_logger.debug(f'\nReceived StartExtractedFsDump ({USB_CMD_START_EXTRACTED_FS_DUMP:02X}) command.')
+    g_logger.debug(f'Received StartExtractedFsDump ({USB_CMD_START_EXTRACTED_FS_DUMP:02X}) command.')
 
     if g_nspTransferMode:
         g_logger.error('\nStartExtractedFsDump received mid NSP transfer.\n')
@@ -1300,7 +1301,6 @@ def usbHandleStartExtractedFsDump(cmd_block: bytes) -> int:
     else:
         g_logger.debug(f'Starting extracted FS dump (size 0x{extracted_fs_size:X}, output relative path "{extracted_fs_root_path}").')
     
-    #g_extractedFsAbsRoot = extracted_fs_root_path
     g_extractedFsAbsRoot = os.path.abspath(g_outputDir + os.path.sep + extracted_fs_root_path)
     g_extractedFsAbsRoot = utilsStripWinPrefix(g_extractedFsAbsRoot) #if g_isWindows else g_extractedFsAbsRoot
     g_extractedFsDumpMode = True
@@ -1312,7 +1312,8 @@ def usbHandleStartExtractedFsDump(cmd_block: bytes) -> int:
 def usbHandleEndExtractedFsDump(cmd_block: bytes) -> int:
     global g_extractedFsDumpMode, g_extractedFsAbsRoot
     assert g_logger is not None
-    g_logger.debug(f'\nReceived EndExtractedFsDump ({USB_CMD_END_EXTRACTED_FS_DUMP:02X}) command.')
+    g_logger.debug(f'Received EndExtractedFsDump ({USB_CMD_END_EXTRACTED_FS_DUMP:02X}) command.')
+    g_logger.info(f'Finished extracted FS dump.')
     if not g_logVerbose:
         g_logger.info(f'\nExtracted FS dump complete!\n')
         utilsLogTransferStats(time.time() - g_startTime)

--- a/host/nxdt_host.py
+++ b/host/nxdt_host.py
@@ -787,6 +787,10 @@ def usbHandleSendFileProperties(cmd_block: bytes) -> int | None:
         # Generate full, absolute path to the destination file.
         fullpath = os.path.abspath(g_outputDir + os.path.sep + filename)
 
+        # Unconditionally enable 32-bit paths on Windows.
+        if g_isWindows:
+           fullpath = '\\\\?\\' + fullpath.replace("/", "\\")
+
         # Get parent directory path.
         dirpath = os.path.dirname(fullpath)
 
@@ -822,6 +826,11 @@ def usbHandleSendFileProperties(cmd_block: bytes) -> int | None:
         # Retrieve what we need using global variables.
         file = g_nspFile
         fullpath = g_nspFilePath
+        
+        # Unconditionally enable 32-bit paths on Windows.
+        if g_isWindows:
+           fullpath = '\\\\?\\' + fullpath.replace("/", "\\")
+
         dirpath = os.path.dirname(fullpath)
 
     # Check if we're dealing with an empty file or with the first SendFileProperties command from a NSP.


### PR DESCRIPTION
This PR does a few things on the server side, not to the core functionality at all but mainly consists of what I think are enhancements to the logging; my hope is you agree. I tried not to change the look of the UI and nor did I refactor any code out. I also tried to adhere to the existing naming conventions of variables and functions--point is I'm not trying to step on your toes, but think this might be nice.

Anyway, here's what this does:

- Enables logging to a file named "nxdt_host_DATE_TIME.log" located in target root. This is toggleable from the CLI using the new flag "-l" and in the GUI from a new checkbox (which is enabled by default).
- Enables logging in color in console mode, if the console can handle ANSI command codes, corresponding to the colors already chosen for the UI.
- Prepends the ISO-8601ish date and square-bracketed loglevel to each line of the log during CLI and file logging.
- - Leading and trailing newlines are taken into consideration and processed appropriately by the prepending logic. Other newlines are not (they weren't used at all and arguably shouldn't be) but push comes to shove this should be tractable.
- -  This can be made optional from the command-line easily enough, but would begin to clutter up the GUI, so I decided not to implement this until I had a clearer idea of what you wanted out of the GUI/how you wanted to go about it/how acceptable this PR is, etc.
- Logs some basic environmental and configuration information on script start and on successful connection. 
- Beginning and end of transfer session now logged now appear more prominently. 
- Some basic info listed at the beginning of each transfer:
- - Either the source partition (in case of extracted FS) or the path (in every other case)
- - The total size of the transfer in human-readable format.
- - - In verbose/debug mode, these are omitted.
- During NSP and extracted FS transfers, the path of each constituent file followed by its human-readable size in parentheses appears slightly indented and without the redundant (to the user) target directory, which should give a good idea of both the directory tree and some granular idea of transfer progress generally, especially during extracted FS transfers. 
- At the end of each session, the total size of the transfer and the time it took (in seconds if it took less than 60, in formatted [h:mm:ss] if it took longer) is listed.
- - If the transfer took at least two seconds, the average transfer rate is listed as well. 

Other minor changes:
-The bottom padding of elements at the bottom of the GUI are now tied to the font size; this is slightly cleaner-looking. 
-The choose-directory prompt, instead of being seeded with the same root directory each time, will start from the last directory that was successfully submitted to it since the beginning of the program. If that directory was moved or deleted, then it will revert back to the default behavior. 
-Refactored my earlier path-fixing code on Windows, removed it from one spot entirely (it was redundant, and so, prepended the magic string twice) and added references. Also, the paths aren't '32-bit' as I wrote earlier, but rather ~32,767 2-byte characters long. 

I will also add logs and screenshots momentarily. 

Limitations and possible pitfalls:
- I may have screwed up some variable scoping, which I'm not totally confident in.
- Some of my comments are long. Maybe should use docstrings?
- Probably there is more refactoring that can be done, mainly around the end-of-transfer log stuff, since this has to be done in three different places (individual files, NSP, and extracted FS) and what is done is broadly similar with only some differences, but maybe other places. 
- Timestamp prepending I thought wasn't too ugly and generally I am glad to have not had to resort to any regexes, but maybe you have a better way of handling this? 
- I have only been able to test with my personal machine running Windows 11 and Python 3.11 and 3.12. I don't expect major issues but of course that's the entire point of testing...ETA: I basically assumed that any modern *nix terminal can handle ANSI control characters and color output, and have no idea if this is actually true.

Otherwise, my preference is, uh, not to maintain and sync a fork for the sake of these cosmetic changes, so if there is something unacceptable here (or hell, even if it's all trash), please let me know, and maybe I could make it right. Otherwise, thanks again for your time and your support of this project!