### PR TITLE
Standardize complete gamecard image

### DIFF
--- a/include/core/fs_ext.h
+++ b/include/core/fs_ext.h
@@ -108,9 +108,9 @@ NXDT_ASSERT(FsCardId3, 0x4);
 
 /// Returned by fsDeviceOperatorGetGameCardIdSet.
 typedef struct {
-    FsCardId1 id1;
-    FsCardId2 id2;
-    FsCardId3 id3;
+    FsCardId1 id1;      ///< Specifies maker code, memory capacity, and memory type
+    FsCardId2 id2;      ///< Specifies card security number and card type
+    FsCardId3 id3;      ///< Always zero (so far)
 } FsGameCardIdSet;
 
 NXDT_ASSERT(FsGameCardIdSet, 0xC);

--- a/source/core/gamecard.c
+++ b/source/core/gamecard.c
@@ -961,10 +961,6 @@ static bool gamecardReadSecurityInformation(GameCardSecurityInformation *out)
             /* Jackpot. */
             memcpy(out, g_fsProgramMemory.data + offset + sizeof(GameCardInitialData) - sizeof(GameCardSecurityInformation), sizeof(GameCardSecurityInformation));
 
-            /* Clear out the current ASIC session hash. */
-            /* It's not actually part of the gamecard data, and this changes every time a gamecard (re)insertion takes place. */
-            memset(out->specific_data.asic_session_hash, 0xFF, sizeof(out->specific_data.asic_session_hash));
-
             found = true;
             break;
         }


### PR DESCRIPTION
This PR attempts to standardize what constitutes a full gamecard image: `XCI` + `(Initial Data)` + `(Certificate)` + `(Card ID Set)` + `(Card UID)`. These file outputs are also unaffected (*) by any future Switch system update where nxdumptool is launched from, effectively creating an immutable and complete data set for the entire gamecard.

The gamecard menu has moved the items around such that the first dump options are those mentioned above: `XCI`, then `(Initial Data)`, then `(Certificate)`, then `(Card ID Set)` and then `(Card UID)`.

Additionally, the `(Specific Data)` is no longer modified (such as clearing the ASIC session hash) and is now left as-is. Its only useful purpose was the gamecard UID, and this has now been moved into a seperate `(Card UID)` file. The `(Specific Data)` file should be treated mostly as something for developers, as it is uninteresting for game preservationists. 

(*): In the absolute worst case where the LAFW Specific Data internal format should change drastically, we would need to find and extract the UID on a firmware-by-firmware basis and update nxdumptool accordingly.