### PR TITLE
Bulk queued NSP dumping

### DIFF
--- a/code_templates/nxdt_rw_poc.c
+++ b/code_templates/nxdt_rw_poc.c
@@ -32,9 +32,10 @@
 #include <core/system_update.h>
 #include <core/bis_storage.h>
 
-#define BLOCK_SIZE      USB_TRANSFER_BUFFER_SIZE
-#define WAIT_TIME_LIMIT 30
-#define OUTDIR          APP_TITLE
+#define DEFAULT_PAGE_SIZE   20
+#define BLOCK_SIZE          USB_TRANSFER_BUFFER_SIZE
+#define WAIT_TIME_LIMIT     30
+#define OUTDIR              APP_TITLE
 
 /* Type definitions. */
 
@@ -206,6 +207,7 @@ static void freeNspQueueViewList(void);
 static bool expandNspQueueViewList(TitleInfo *title_info);
 static int nspDumpQueueViewListEntrySortFunction(const void *a, const void *b);
 static void removeNspDumpQueueViewListEntryByTitleInfoPtr(TitleInfo *title_info);
+static void addAllUserTitlesToNspDumpQueueViewList(const u32 user_titles_count);
 
 NX_INLINE bool useUsbHost(void);
 
@@ -239,9 +241,11 @@ static bool saveConsoleLafwBlob(void *userdata);
 
 static bool saveNintendoSubmissionPackage(void *userdata);
 
-static bool addNintendoSubmissionPackageToQueue(void *userdata);
-static bool addAllAvailableNintendoSubmissionPackagesToQueue(void *userdata);
-static bool startNintendoSubmissionPackageQueue(void *userdata);
+static bool addTitleToNintendoSubmissionPackageQueue(TitleInfo *title_info, bool print_err_only);
+static bool addTitleToNintendoSubmissionPackageQueueByUserAction(void *userdata);
+static u32 addAllUserApplicationDataTitlesToNintendoSubmissionPackageQueue(TitleUserApplicationData *user_app_data, bool print_err_only);
+static bool addAllUserApplicationDataTitlesToNintendoSubmissionPackageQueueByUserAction(void *userdata);
+static bool startNintendoSubmissionPackageQueueDump(void *userdata);
 static bool clearNintendoSubmissionPackageQueue(void *userdata);
 static bool removeNintendoSubmissionPackageQueueEntry(void *userdata);
 
@@ -747,7 +751,7 @@ static MenuElement *g_nspMenuElements[] = {
     &(MenuElement){
         .str = "add selected title to nsp queue",
         .child_menu = NULL,
-        .task_func = &addNintendoSubmissionPackageToQueue,
+        .task_func = &addTitleToNintendoSubmissionPackageQueueByUserAction,
         .element_options = NULL,
         .userdata = NULL    // Dynamically set to the TitleInfo object from the title to queue
     },
@@ -834,7 +838,7 @@ static MenuElement *g_nspQueueMenuElements[] = {
     &(MenuElement){
         .str = "start queued nsp dump",
         .child_menu = NULL,
-        .task_func = &startNintendoSubmissionPackageQueue,
+        .task_func = &startNintendoSubmissionPackageQueueDump,
         .element_options = NULL,
         .userdata = NULL
     },
@@ -1086,7 +1090,7 @@ static MenuElement *g_nspTitleTypesMenuElements[] = {
     &(MenuElement){
         .str = "add all available titles to nsp queue",
         .child_menu = NULL,
-        .task_func = &addAllAvailableNintendoSubmissionPackagesToQueue,
+        .task_func = &addAllUserApplicationDataTitlesToNintendoSubmissionPackageQueueByUserAction,
         .element_options = NULL,
         .userdata = NULL // Dynamically set to a TitleUserApplicationData object when needed
     },
@@ -1367,7 +1371,7 @@ int main(int argc, char *argv[])
     updateTitleList(&g_systemTitlesMenu, &g_ncaMenu, true);
 
     Menu *cur_menu = &g_rootMenu;
-    u32 element_count = menuGetElementCount(cur_menu), page_size = 20;
+    u32 element_count = menuGetElementCount(cur_menu), page_size = DEFAULT_PAGE_SIZE;
 
     TitleApplicationMetadata *app_metadata = NULL;
 
@@ -1380,18 +1384,6 @@ int main(int argc, char *argv[])
 
     while(appletMainLoop())
     {
-        /* Clamp selection on NSP queue list because it could have been changed. */
-        if (cur_menu->id == MenuId_NspQueueView)
-        {
-            element_count = g_nspQueueViewMenuElementCount;
-
-            if (cur_menu->selected >= element_count)
-            {
-                cur_menu->selected = (element_count ? (element_count - 1) : 0);
-                cur_menu->scroll = (element_count >= page_size ? (element_count - page_size) : 0);
-            }
-        }
-
         MenuElement *selected_element = ((cur_menu->elements && element_count && cur_menu->selected < element_count) ? cur_menu->elements[cur_menu->selected] : NULL);
         MenuElementOption *selected_element_options = (selected_element ? selected_element->element_options : NULL);
 
@@ -1417,7 +1409,11 @@ int main(int argc, char *argv[])
         consolePrint("______________________________\n\n");
         if (cur_menu->parent) consolePrint("press b to go back\n");
         if (g_umsDeviceCount) consolePrint("press x to safely remove all ums devices\n");
-        if ((cur_menu->id == MenuId_UserTitles || cur_menu->id == MenuId_SystemTitles) && element_count) consolePrint("press y to dump csv with title info to the sd card\n");
+        if ((cur_menu->id == MenuId_UserTitles || cur_menu->id == MenuId_SystemTitles) && element_count)
+        {
+            consolePrint("press y to dump csv with title info to the sd card\n");
+            consolePrint("press zl + zr to add all titles to the nsp dump queue\n");
+        }
         consolePrint("use the sticks to scroll faster\n");
         consolePrint("press + to exit\n");
         consolePrint("______________________________\n\n");
@@ -1503,8 +1499,14 @@ int main(int argc, char *argv[])
         if (cur_menu->id == MenuId_NspQueue || cur_menu->id == MenuId_NspQueueView)
         {
             consolePrint("nsp queue status:\n\n");
-            consolePrint("queued items: %u\n", g_nspQueueViewMenuElementCount);
-            if (cur_menu->id == MenuId_NspQueueView) consolePrint("press a on an entry to remove it from the queue\n");
+            if (cur_menu->id == MenuId_NspQueueView && selected_element)
+            {
+                consolePrint("nsp: %u / %u\n", cur_menu->selected + 1, element_count);
+                consolePrint("selected nsp: %s\n", selected_element->str);
+                consolePrint("press a on an entry to remove it from the queue\n");
+            } else {
+                consolePrint("queued items: %u\n", g_nspQueueViewMenuElementCount);
+            }
             consolePrint("______________________________\n\n");
         }
 
@@ -1693,8 +1695,8 @@ int main(int argc, char *argv[])
                 but we don't want to wait for USB or show the "please wait" message
                 since these actions are usually very fast and waiting for USB or
                 showing the message could be disruptive. */
-                bool is_queue_management_action = (selected_element->task_func == &addNintendoSubmissionPackageToQueue || \
-                                                   selected_element->task_func == &addAllAvailableNintendoSubmissionPackagesToQueue || \
+                bool is_queue_management_action = (selected_element->task_func == &addTitleToNintendoSubmissionPackageQueueByUserAction || \
+                                                   selected_element->task_func == &addAllUserApplicationDataTitlesToNintendoSubmissionPackageQueueByUserAction || \
                                                    selected_element->task_func == &clearNintendoSubmissionPackageQueue || \
                                                    selected_element->task_func == &removeNintendoSubmissionPackageQueueEntry);
 
@@ -1719,7 +1721,7 @@ int main(int argc, char *argv[])
                 } else
                 if (cur_menu->id > MenuId_Root && !is_queue_management_action)
                 {
-                    if (selected_element->task_func != &startNintendoSubmissionPackageQueue || g_nspQueueViewMenuElementCount)
+                    if (selected_element->task_func != &startNintendoSubmissionPackageQueueDump || g_nspQueueViewMenuElementCount)
                     {
                         /* Wait for USB session (if needed). */
                         if (useUsbHost() && !waitForUsb())
@@ -1745,6 +1747,10 @@ int main(int argc, char *argv[])
                 } else {
                     /* Ignore result. */
                     selected_element->task_func(selected_element->userdata);
+
+                    /* Update element count if we're dealing with a NSP queue management action and
+                    we're currently at the NSP queue view menu. */
+                    if (is_queue_management_action && cur_menu->id == MenuId_NspQueueView) element_count = g_nspQueueViewMenuElementCount;
                 }
 
                 if (g_appletStatus && show_button_prompt)
@@ -1793,19 +1799,19 @@ int main(int argc, char *argv[])
                 cur_menu->scroll--;
             }
         } else
-        if (((btn_down & (HidNpadButton_Right | HidNpadButton_StickLRight | HidNpadButton_StickRRight)) || (btn_held & HidNpadButton_StickRDown)) && element_count && !selected_element_options)
+        if (((btn_down & HidNpadButton_AnyRight) || (btn_held & HidNpadButton_StickRDown)) && element_count && !selected_element_options)
         {
             cur_menu->selected += page_size;
             if (cur_menu->selected >= element_count) cur_menu->selected = (element_count - 1);
             cur_menu->scroll = (cur_menu->selected - (cur_menu->selected % page_size));
         } else
-        if (((btn_down & (HidNpadButton_Left | HidNpadButton_StickLLeft | HidNpadButton_StickRLeft)) || (btn_held & HidNpadButton_StickRUp)) && element_count && !selected_element_options)
+        if (((btn_down & HidNpadButton_AnyLeft) || (btn_held & HidNpadButton_StickRUp)) && element_count && !selected_element_options)
         {
             cur_menu->selected -= page_size;
             if (cur_menu->selected >= (UINT32_MAX - page_size) && cur_menu->selected <= UINT32_MAX) cur_menu->selected = 0;
             cur_menu->scroll = (cur_menu->selected - (cur_menu->selected % page_size));
         } else
-        if ((btn_down & (HidNpadButton_Right | HidNpadButton_StickLRight | HidNpadButton_StickRRight)) && selected_element_options)
+        if ((btn_down & HidNpadButton_AnyRight) && selected_element_options)
         {
             /* Point to the next base/patch title. */
             if (cur_menu->id == MenuId_NcaFsSectionsSubMenu && cur_menu->selected == 2)
@@ -1825,7 +1831,7 @@ int main(int argc, char *argv[])
             if (!selected_element_options->options[selected_element_options->selected]) selected_element_options->selected--;
             if (selected_element_options->setter_func) selected_element_options->setter_func(selected_element_options->selected);
         } else
-        if ((btn_down & (HidNpadButton_Left | HidNpadButton_StickLLeft | HidNpadButton_StickRLeft)) && selected_element_options)
+        if ((btn_down & HidNpadButton_AnyLeft) && selected_element_options)
         {
             selected_element_options->selected--;
             if (selected_element_options->selected == UINT32_MAX) selected_element_options->selected = 0;
@@ -1965,6 +1971,10 @@ int main(int argc, char *argv[])
                 g_ncaMenuElements[i]->child_menu = (g_ncaMenuRawMode ? NULL : &g_ncaFsSectionsMenu);
                 g_ncaMenuElements[i]->task_func = (g_ncaMenuRawMode ? &saveNintendoContentArchive : NULL);
             }
+        } else
+        if ((btn_down & (HidNpadButton_ZL | HidNpadButton_ZR)) && cur_menu->id == MenuId_UserTitles && element_count)
+        {
+            addAllUserTitlesToNspDumpQueueViewList(element_count);
         } else
         if (btn_down & HidNpadButton_Plus)
         {
@@ -2335,7 +2345,61 @@ static void removeNspDumpQueueViewListEntryByTitleInfoPtr(TitleInfo *title_info)
 
     if (idx < (g_nspQueueViewMenuElementCount - 1)) memmove(&(g_nspQueueViewMenu.elements[idx]), &(g_nspQueueViewMenu.elements[idx + 1]), (g_nspQueueViewMenuElementCount - idx) * sizeof(MenuElement*)); // Move NULL terminator too
 
-    if (!--g_nspQueueViewMenuElementCount) freeNspQueueViewList();
+    if (--g_nspQueueViewMenuElementCount)
+    {
+        if (g_nspQueueViewMenu.selected >= g_nspQueueViewMenuElementCount)
+        {
+            g_nspQueueViewMenu.selected = (g_nspQueueViewMenuElementCount - 1);
+            g_nspQueueViewMenu.scroll = (g_nspQueueViewMenuElementCount >= DEFAULT_PAGE_SIZE ? (g_nspQueueViewMenuElementCount - DEFAULT_PAGE_SIZE) : 0);
+        }
+    } else {
+        freeNspQueueViewList();
+    }
+}
+
+static void addAllUserTitlesToNspDumpQueueViewList(const u32 user_titles_count)
+{
+    if (!user_titles_count || !g_userTitlesMenu.elements) return;
+
+    consoleClear();
+
+    consolePrint("warning: this will queue all available nsp dump targets from every user title entry\n");
+    consolePrint("including latest base apps, latest updates, all dlc and dlc updates\n");
+    consolePrint("press a to proceed, or b to cancel\n\n");
+
+    u64 btn_down = utilsWaitForButtonPress(HidNpadButton_A | HidNpadButton_B);
+    if (btn_down & HidNpadButton_B)
+    {
+        consolePrint("global bulk queue add cancelled\n");
+        goto end;
+    }
+
+    consoleClear();
+    consolePrint("adding all titles to queue, please wait...\n");
+    consoleRefresh();
+
+    u32 added = 0;
+
+    for(u32 i = 0; i < user_titles_count; i++)
+    {
+        MenuElement *cur_menu_element = g_userTitlesMenu.elements[i];
+        TitleApplicationMetadata *cur_app_metadata = (cur_menu_element ? (TitleApplicationMetadata*)cur_menu_element->userdata : NULL);
+        if (!cur_app_metadata) continue;
+
+        TitleUserApplicationData user_app_data = {0};
+        if (!titleGetUserApplicationData(cur_app_metadata->title_id, &user_app_data)) continue;
+
+        added += addAllUserApplicationDataTitlesToNintendoSubmissionPackageQueue(&user_app_data, true);
+        consoleRefresh();
+
+        titleFreeUserApplicationData(&user_app_data);
+    }
+
+    consolePrint("global bulk queue add finished: %u item(s) added\n", added);
+
+end:
+    consolePrint("press any button to go back\n");
+    utilsWaitForButtonPress(0);
 }
 
 static TitleInfo *getLatestTitleInfo(TitleInfo *title_info, u32 *out_idx, u32 *out_count)
@@ -3924,29 +3988,33 @@ static bool saveNintendoSubmissionPackage(void *userdata)
     return success;
 }
 
-static bool addNintendoSubmissionPackageToQueue(void *userdata)
+static bool addTitleToNintendoSubmissionPackageQueue(TitleInfo *title_info, bool print_err_only)
 {
-    if (!userdata) return false;
+    if (!title_info) return false;
 
-    TitleInfo *title_info = NULL;
+    TitleInfo *title_info_dup = NULL;
+    char err_str[0x100] = {0};
     bool success = false;
 
-    title_info = titleDuplicateTitleInfo((TitleInfo*)userdata, false);
-    if (!title_info)
+    snprintf(err_str, MAX_ELEMENTS(err_str), "unable to add title %016lX v%u [%s] to queue", title_info->meta_key.id, title_info->version.value, \
+                                                                                             titleGetNcmStorageIdName(title_info->storage_id));
+
+    title_info_dup = titleDuplicateTitleInfo(title_info, false);
+    if (!title_info_dup)
     {
-        consolePrint("failed to duplicate title info for queue\n");
+        consolePrint("%s: failed to duplicate title info\n", err_str);
         goto end;
     }
 
-    if (title_info->storage_id != NcmStorageId_GameCard && title_info->storage_id != NcmStorageId_BuiltInUser && title_info->storage_id != NcmStorageId_SdCard)
+    if (title_info_dup->storage_id != NcmStorageId_GameCard && title_info_dup->storage_id != NcmStorageId_BuiltInUser && title_info_dup->storage_id != NcmStorageId_SdCard)
     {
-        consolePrint("queue only supports emmc, sd card and/or gamecard titles\n");
+        consolePrint("%s: only emmc, sd card and/or gamecard titles are supported\n", err_str);
         goto end;
     }
 
-    if (title_info->meta_key.type < NcmContentMetaType_Application || title_info->meta_key.type > NcmContentMetaType_DataPatch || title_info->meta_key.type == NcmContentMetaType_Delta)
+    if (title_info_dup->meta_key.type < NcmContentMetaType_Application || title_info_dup->meta_key.type > NcmContentMetaType_DataPatch || title_info_dup->meta_key.type == NcmContentMetaType_Delta)
     {
-        consolePrint("invalid title type for nsp queue\n");
+        consolePrint("%s: invalid title type 0x%02X (%s)\n", err_str, title_info_dup->meta_key.type, titleGetNcmContentMetaTypeName(title_info_dup->meta_key.type));
         goto end;
     }
 
@@ -3954,70 +4022,65 @@ static bool addNintendoSubmissionPackageToQueue(void *userdata)
     {
         MenuElement *cur_menu_element = g_nspQueueViewMenu.elements[i];
         TitleInfo *entry = (cur_menu_element ? (TitleInfo*)cur_menu_element->userdata : NULL);
-        if (!entry || entry->meta_key.id != title_info->meta_key.id || entry->meta_key.type != title_info->meta_key.type) continue;
+        if (!entry || entry->meta_key.id != title_info_dup->meta_key.id || entry->meta_key.type != title_info_dup->meta_key.type) continue;
 
-        if (entry->version.value >= title_info->version.value)
+        if (entry->version.value >= title_info_dup->version.value)
         {
-            consolePrint("title %016lX with equal or greater version already queued (v%u >= v%u)\n", entry->meta_key.id, entry->version.value, title_info->version.value);
+            consolePrint("%s: title with equal or greater version (v%u [%s]) already queued\n", err_str, entry->version.value, titleGetNcmStorageIdName(entry->storage_id));
             goto end;
         }
 
-        consolePrint("updating queued title %016lX to a newer preferred entry (v%u -> v%u)\n", entry->meta_key.id, entry->version.value, title_info->version.value);
+        consolePrint("updating queued title %016lX to a newer preferred entry (v%u [%s] -> v%u [%s])\n", entry->meta_key.id, entry->version.value, titleGetNcmStorageIdName(entry->storage_id), \
+                                                                                                         title_info_dup->version.value, titleGetNcmStorageIdName(title_info_dup->storage_id));
 
         if (cur_menu_element->str) free(cur_menu_element->str);
         titleFreeTitleInfo((TitleInfo**)&(cur_menu_element->userdata));
 
-        cur_menu_element->str = titleGenerateFileName(title_info, TitleNamingConvention_Full, TitleFileNameIllegalCharReplaceType_IllegalFsChars);
-        cur_menu_element->userdata = title_info;
+        cur_menu_element->str = titleGenerateFileName(title_info_dup, TitleNamingConvention_Full, TitleFileNameIllegalCharReplaceType_IllegalFsChars);
+        cur_menu_element->userdata = title_info_dup;
 
         success = true;
 
         goto end;
     }
 
-    if (!expandNspQueueViewList(title_info))
+    if (!expandNspQueueViewList(title_info_dup))
     {
-        consolePrint("failed to expand nsp queue\n");
+        consolePrint("%s: failed to expand nsp queue\n", err_str);
         goto end;
     }
 
-    consolePrint("queued %s title %016lX v%u (%u item[s] total)\n", titleGetNcmStorageIdName(title_info->storage_id), title_info->meta_key.id, title_info->meta_key.version, g_nspQueueViewMenuElementCount);
+    if (!print_err_only)
+    {
+        consolePrint("queued title %016lX v%u [%s] (%u item[s] total)\n", title_info_dup->meta_key.id, title_info_dup->meta_key.version, titleGetNcmStorageIdName(title_info_dup->storage_id), \
+                                                                          g_nspQueueViewMenuElementCount);
+    }
+
     success = true;
 
 end:
-    if (!success) titleFreeTitleInfo(&title_info);
+    if (!success) titleFreeTitleInfo(&title_info_dup);
 
     return success;
 }
 
-static bool addAllAvailableNintendoSubmissionPackagesToQueue(void *userdata)
+static bool addTitleToNintendoSubmissionPackageQueueByUserAction(void *userdata)
 {
-    TitleUserApplicationData *user_app_data = (TitleUserApplicationData*)userdata;
-    if (!user_app_data)
-    {
-        consolePrint("invalid user application data\n");
-        return false;
-    }
+    return addTitleToNintendoSubmissionPackageQueue((TitleInfo*)userdata, false);
+}
 
-    consolePrint("warning: this will queue all available nsp dump targets for the selected user\n");
-    consolePrint("title entry, including base app, latest update, all dlc and dlc updates\n");
-    consolePrint("press a to proceed, or b to cancel\n\n");
-
-    u64 btn_down = utilsWaitForButtonPress(HidNpadButton_A | HidNpadButton_B);
-    if (btn_down & HidNpadButton_B)
-    {
-        consolePrint("bulk queue add cancelled\n");
-        return false;
-    }
+static u32 addAllUserApplicationDataTitlesToNintendoSubmissionPackageQueue(TitleUserApplicationData *user_app_data, bool print_err_only)
+{
+    if (!user_app_data) return 0;
 
     u64 cur_id = 0;
     u32 added = 0;
 
     TitleInfo *latest_app = getLatestTitleInfo(user_app_data->app_info, NULL, NULL);
-    if (latest_app && addNintendoSubmissionPackageToQueue(latest_app)) added++;
+    if (latest_app && addTitleToNintendoSubmissionPackageQueue(latest_app, print_err_only)) added++;
 
     TitleInfo *latest_patch = getLatestTitleInfo(user_app_data->patch_info, NULL, NULL);
-    if (latest_patch && addNintendoSubmissionPackageToQueue(latest_patch)) added++;
+    if (latest_patch && addTitleToNintendoSubmissionPackageQueue(latest_patch, print_err_only)) added++;
 
     for(TitleInfo *entry = user_app_data->aoc_info; entry; entry = entry->next)
     {
@@ -4027,7 +4090,7 @@ static bool addAllAvailableNintendoSubmissionPackagesToQueue(void *userdata)
         cur_id = entry->meta_key.id;
 
         TitleInfo *latest_aoc = getLatestTitleInfo(entry, NULL, NULL);
-        if (latest_aoc && addNintendoSubmissionPackageToQueue(latest_aoc)) added++;
+        if (latest_aoc && addTitleToNintendoSubmissionPackageQueue(latest_aoc, print_err_only)) added++;
     }
 
     cur_id = 0;
@@ -4040,15 +4103,40 @@ static bool addAllAvailableNintendoSubmissionPackagesToQueue(void *userdata)
         cur_id = entry->meta_key.id;
 
         TitleInfo *latest_aoc_patch = getLatestTitleInfo(entry, NULL, NULL);
-        if (latest_aoc_patch && addNintendoSubmissionPackageToQueue(latest_aoc_patch)) added++;
+        if (latest_aoc_patch && addTitleToNintendoSubmissionPackageQueue(latest_aoc_patch, print_err_only)) added++;
     }
+
+    return added;
+}
+
+static bool addAllUserApplicationDataTitlesToNintendoSubmissionPackageQueueByUserAction(void* userdata)
+{
+    TitleUserApplicationData *user_app_data = (TitleUserApplicationData*)userdata;
+    if (!user_app_data)
+    {
+        consolePrint("invalid user application data\n");
+        return false;
+    }
+
+    consolePrint("warning: this will queue all available nsp dump targets for the selected user\n");
+    consolePrint("title entry, including latest base app, latest update, all dlc and dlc updates\n");
+    consolePrint("press a to proceed, or b to cancel\n\n");
+
+    u64 btn_down = utilsWaitForButtonPress(HidNpadButton_A | HidNpadButton_B);
+    if (btn_down & HidNpadButton_B)
+    {
+        consolePrint("bulk queue add cancelled\n");
+        return false;
+    }
+
+    const u32 added = addAllUserApplicationDataTitlesToNintendoSubmissionPackageQueue(user_app_data, false);
 
     consolePrint("bulk queue add finished: %u item(s) added\n", added);
 
     return (added > 0);
 }
 
-static bool startNintendoSubmissionPackageQueue(void *userdata)
+static bool startNintendoSubmissionPackageQueueDump(void *userdata)
 {
     NX_IGNORE_ARG(userdata);
 
@@ -4571,7 +4659,7 @@ static bool fsBrowser(const char *mount_name, const char *base_out_path)
     FsBrowserEntry *entries = NULL;
     u32 entries_count = 0, depth = 0;
 
-    u32 scroll = 0, selected = 0, highlighted = 0, page_size = 20;
+    u32 scroll = 0, selected = 0, highlighted = 0, page_size = DEFAULT_PAGE_SIZE;
 
     bool success = true;
 

--- a/code_templates/nxdt_rw_poc.c
+++ b/code_templates/nxdt_rw_poc.c
@@ -87,7 +87,9 @@ typedef enum {
     MenuId_SystemTitles         = 15,
     MenuId_SystemUpdate         = 16,
     MenuId_BrowseEmmc           = 17,
-    MenuId_Count                = 18
+    MenuId_NspQueue             = 18,
+    MenuId_NspQueueView         = 19,
+    MenuId_Count                = 20
 } MenuId;
 
 typedef struct
@@ -168,6 +170,13 @@ typedef struct {
     SystemUpdateDumpContext *sys_upd_dump_ctx;
 } SystemUpdateThreadData;
 
+typedef struct {
+    u64 title_id;
+    u8 meta_type;
+    bool is_system;
+    char name[0x201];
+} NspQueueEntry;
+
 /* Function prototypes. */
 
 static void utilsScanPads(void);
@@ -200,6 +209,9 @@ void updateNcaFsSectionsList(NcaUserData *nca_user_data);
 void freeNcaBasePatchList(void);
 void updateNcaBasePatchList(TitleUserApplicationData *user_app_data, TitleInfo *title_info, NcaFsSectionContext *nca_fs_ctx);
 
+void freeNspQueueViewList(void);
+void updateNspQueueViewList(void);
+
 NX_INLINE bool useUsbHost(void);
 
 static bool waitForGameCard(void);
@@ -229,6 +241,11 @@ static bool saveGameCardExtractedHfsPartition(HashFileSystemContext *hfs_ctx);
 static bool browseGameCardHfsPartition(void *userdata);
 
 static bool saveConsoleLafwBlob(void *userdata);
+
+static bool addNintendoSubmissionPackageToQueue(void *userdata);
+static bool startNintendoSubmissionPackageQueue(void *userdata);
+static bool clearNintendoSubmissionPackageQueue(void *userdata);
+static bool removeNintendoSubmissionPackageQueueEntry(void *userdata);
 
 static bool saveNintendoSubmissionPackage(void *userdata);
 
@@ -364,6 +381,73 @@ static MenuElement g_storageMenuElement = {
     .task_func = NULL,
     .element_options = &g_storageMenuElementOption,
     .userdata = NULL
+};
+
+static NspQueueEntry *g_nspDumpQueue = NULL;
+static u32 g_nspDumpQueueCount = 0;
+
+static MenuElementOption g_nspSetDownloadDistributionMenuElementOption = {
+    .selected = 0,
+    .retrieved = false,
+    .getter_func = &getNspSetDownloadDistributionOption,
+    .setter_func = &setNspSetDownloadDistributionOption,
+    .options = g_noYesStrings
+};
+
+static MenuElementOption g_nspRemoveConsoleDataMenuElementOption = {
+    .selected = 0,
+    .retrieved = false,
+    .getter_func = &getNspRemoveConsoleDataOption,
+    .setter_func = &setNspRemoveConsoleDataOption,
+    .options = g_noYesStrings
+};
+
+static MenuElementOption g_nspRemoveTitlekeyCryptoMenuElementOption = {
+    .selected = 0,
+    .retrieved = false,
+    .getter_func = &getNspRemoveTitlekeyCryptoOption,
+    .setter_func = &setNspRemoveTitlekeyCryptoOption,
+    .options = g_noYesStrings
+};
+
+static MenuElementOption g_nspDisableLinkedAccountRequirementMenuElementOption = {
+    .selected = 1,
+    .retrieved = false,
+    .getter_func = &getNspDisableLinkedAccountRequirementOption,
+    .setter_func = &setNspDisableLinkedAccountRequirementOption,
+    .options = g_noYesStrings
+};
+
+static MenuElementOption g_nspEnableScreenshotsMenuElementOption = {
+    .selected = 1,
+    .retrieved = false,
+    .getter_func = &getNspEnableScreenshotsOption,
+    .setter_func = &setNspEnableScreenshotsOption,
+    .options = g_noYesStrings
+};
+
+static MenuElementOption g_nspEnableVideoCaptureMenuElementOption = {
+    .selected = 1,
+    .retrieved = false,
+    .getter_func = &getNspEnableVideoCaptureOption,
+    .setter_func = &setNspEnableVideoCaptureOption,
+    .options = g_noYesStrings
+};
+
+static MenuElementOption g_nspDisableHdcpMenuElementOption = {
+    .selected = 1,
+    .retrieved = false,
+    .getter_func = &getNspDisableHdcpOption,
+    .setter_func = &setNspDisableHdcpOption,
+    .options = g_noYesStrings
+};
+
+static MenuElementOption g_nspGenerateAuthoringToolDataMenuElementOption = {
+    .selected = 1,
+    .retrieved = false,
+    .getter_func = &getNspGenerateAuthoringToolDataOption,
+    .setter_func = &setNspGenerateAuthoringToolDataOption,
+    .options = g_noYesStrings
 };
 
 static MenuElement *g_xciMenuElements[] = {
@@ -666,107 +750,66 @@ static MenuElement *g_nspMenuElements[] = {
         .userdata = NULL    // Dynamically set to the TitleInfo object from the title to dump
     },
     &(MenuElement){
+        .str = "add selected title to nsp queue",
+        .child_menu = NULL,
+        .task_func = &addNintendoSubmissionPackageToQueue,
+        .element_options = NULL,
+        .userdata = NULL    // Dynamically set to the TitleInfo object from the title to queue
+    },
+    &(MenuElement){
         .str = "nca: set content distribution type to \"download\"",
         .child_menu = NULL,
         .task_func = NULL,
-        .element_options = &(MenuElementOption){
-            .selected = 0,
-            .retrieved = false,
-            .getter_func = &getNspSetDownloadDistributionOption,
-            .setter_func = &setNspSetDownloadDistributionOption,
-            .options = g_noYesStrings
-        },
+        .element_options = &g_nspSetDownloadDistributionMenuElementOption,
         .userdata = NULL
     },
     &(MenuElement){
         .str = "tik: remove console specific data",
         .child_menu = NULL,
         .task_func = NULL,
-        .element_options = &(MenuElementOption){
-            .selected = 0,
-            .retrieved = false,
-            .getter_func = &getNspRemoveConsoleDataOption,
-            .setter_func = &setNspRemoveConsoleDataOption,
-            .options = g_noYesStrings
-        },
+        .element_options = &g_nspRemoveConsoleDataMenuElementOption,
         .userdata = NULL
     },
     &(MenuElement){
         .str = "nca/tik: remove titlekey crypto (overrides previous option)",
         .child_menu = NULL,
         .task_func = NULL,
-        .element_options = &(MenuElementOption){
-            .selected = 0,
-            .retrieved = false,
-            .getter_func = &getNspRemoveTitlekeyCryptoOption,
-            .setter_func = &setNspRemoveTitlekeyCryptoOption,
-            .options = g_noYesStrings
-        },
+        .element_options = &g_nspRemoveTitlekeyCryptoMenuElementOption,
         .userdata = NULL
     },
     &(MenuElement){
         .str = "nacp: disable linked account requirement",
         .child_menu = NULL,
         .task_func = NULL,
-        .element_options = &(MenuElementOption){
-            .selected = 1,
-            .retrieved = false,
-            .getter_func = &getNspDisableLinkedAccountRequirementOption,
-            .setter_func = &setNspDisableLinkedAccountRequirementOption,
-            .options = g_noYesStrings
-        },
+        .element_options = &g_nspDisableLinkedAccountRequirementMenuElementOption,
         .userdata = NULL
     },
     &(MenuElement){
         .str = "nacp: enable screenshots",
         .child_menu = NULL,
         .task_func = NULL,
-        .element_options = &(MenuElementOption){
-            .selected = 1,
-            .retrieved = false,
-            .getter_func = &getNspEnableScreenshotsOption,
-            .setter_func = &setNspEnableScreenshotsOption,
-            .options = g_noYesStrings
-        },
+        .element_options = &g_nspEnableScreenshotsMenuElementOption,
         .userdata = NULL
     },
     &(MenuElement){
         .str = "nacp: enable video capture",
         .child_menu = NULL,
         .task_func = NULL,
-        .element_options = &(MenuElementOption){
-            .selected = 1,
-            .retrieved = false,
-            .getter_func = &getNspEnableVideoCaptureOption,
-            .setter_func = &setNspEnableVideoCaptureOption,
-            .options = g_noYesStrings
-        },
+        .element_options = &g_nspEnableVideoCaptureMenuElementOption,
         .userdata = NULL
     },
     &(MenuElement){
         .str = "nacp: disable hdcp",
         .child_menu = NULL,
         .task_func = NULL,
-        .element_options = &(MenuElementOption){
-            .selected = 1,
-            .retrieved = false,
-            .getter_func = &getNspDisableHdcpOption,
-            .setter_func = &setNspDisableHdcpOption,
-            .options = g_noYesStrings
-        },
+        .element_options = &g_nspDisableHdcpMenuElementOption,
         .userdata = NULL
     },
     &(MenuElement){
         .str = "nsp: generate authoringtool data",
         .child_menu = NULL,
         .task_func = NULL,
-        .element_options = &(MenuElementOption){
-            .selected = 1,
-            .retrieved = false,
-            .getter_func = &getNspGenerateAuthoringToolDataOption,
-            .setter_func = &setNspGenerateAuthoringToolDataOption,
-            .options = g_noYesStrings
-        },
+        .element_options = &g_nspGenerateAuthoringToolDataMenuElementOption,
         .userdata = NULL
     },
     &g_storageMenuElement,
@@ -779,6 +822,106 @@ static Menu g_nspMenu = {
     .selected = 0,
     .scroll = 0,
     .elements = g_nspMenuElements
+};
+
+static MenuElement **g_nspQueueViewMenuElements = NULL;
+
+static Menu g_nspQueueViewMenu = {
+    .id = MenuId_NspQueueView,
+    .parent = NULL,
+    .selected = 0,
+    .scroll = 0,
+    .elements = NULL
+};
+
+static MenuElement *g_nspQueueMenuElements[] = {
+    &(MenuElement){
+        .str = "start queued nsp dump",
+        .child_menu = NULL,
+        .task_func = &startNintendoSubmissionPackageQueue,
+        .element_options = NULL,
+        .userdata = NULL
+    },
+    &(MenuElement){
+        .str = "clear nsp queue",
+        .child_menu = NULL,
+        .task_func = &clearNintendoSubmissionPackageQueue,
+        .element_options = NULL,
+        .userdata = NULL
+    },
+    &(MenuElement){
+        .str = "view / remove queued items",
+        .child_menu = &g_nspQueueViewMenu,
+        .task_func = NULL,
+        .element_options = NULL,
+        .userdata = NULL
+    },
+    &(MenuElement){
+        .str = "nca: set content distribution type to \"download\"",
+        .child_menu = NULL,
+        .task_func = NULL,
+        .element_options = &g_nspSetDownloadDistributionMenuElementOption,
+        .userdata = NULL
+    },
+    &(MenuElement){
+        .str = "tik: remove console specific data",
+        .child_menu = NULL,
+        .task_func = NULL,
+        .element_options = &g_nspRemoveConsoleDataMenuElementOption,
+        .userdata = NULL
+    },
+    &(MenuElement){
+        .str = "nca/tik: remove titlekey crypto (overrides previous option)",
+        .child_menu = NULL,
+        .task_func = NULL,
+        .element_options = &g_nspRemoveTitlekeyCryptoMenuElementOption,
+        .userdata = NULL
+    },
+    &(MenuElement){
+        .str = "nacp: disable linked account requirement",
+        .child_menu = NULL,
+        .task_func = NULL,
+        .element_options = &g_nspDisableLinkedAccountRequirementMenuElementOption,
+        .userdata = NULL
+    },
+    &(MenuElement){
+        .str = "nacp: enable screenshots",
+        .child_menu = NULL,
+        .task_func = NULL,
+        .element_options = &g_nspEnableScreenshotsMenuElementOption,
+        .userdata = NULL
+    },
+    &(MenuElement){
+        .str = "nacp: enable video capture",
+        .child_menu = NULL,
+        .task_func = NULL,
+        .element_options = &g_nspEnableVideoCaptureMenuElementOption,
+        .userdata = NULL
+    },
+    &(MenuElement){
+        .str = "nacp: disable hdcp",
+        .child_menu = NULL,
+        .task_func = NULL,
+        .element_options = &g_nspDisableHdcpMenuElementOption,
+        .userdata = NULL
+    },
+    &(MenuElement){
+        .str = "nsp: generate authoringtool data",
+        .child_menu = NULL,
+        .task_func = NULL,
+        .element_options = &g_nspGenerateAuthoringToolDataMenuElementOption,
+        .userdata = NULL
+    },
+    &g_storageMenuElement,
+    NULL
+};
+
+static Menu g_nspQueueMenu = {
+    .id = MenuId_NspQueue,
+    .parent = NULL,
+    .selected = 0,
+    .scroll = 0,
+    .elements = g_nspQueueMenuElements
 };
 
 static MenuElement *g_ticketMenuElements[] = {
@@ -1122,6 +1265,13 @@ static MenuElement *g_rootMenuElements[] = {
         .userdata = NULL
     },
     &(MenuElement){
+        .str = "nsp queue menu",
+        .child_menu = &g_nspQueueMenu,
+        .task_func = NULL,
+        .element_options = NULL,
+        .userdata = NULL
+    },
+    &(MenuElement){
         .str = "reset settings",
         .child_menu = NULL,
         .task_func = &resetSettings,
@@ -1195,6 +1345,17 @@ int main(int argc, char *argv[])
 
     while(appletMainLoop())
     {
+        if (cur_menu->id == MenuId_NspQueueView)
+        {
+            element_count = menuGetElementCount(cur_menu);
+
+            if (cur_menu->selected >= element_count)
+            {
+                cur_menu->selected = (element_count ? (element_count - 1) : 0);
+                cur_menu->scroll = (element_count >= page_size ? (element_count - page_size) : 0);
+            }
+        }
+
         MenuElement *selected_element = ((cur_menu->elements && element_count && cur_menu->selected < element_count) ? cur_menu->elements[cur_menu->selected] : NULL);
         MenuElementOption *selected_element_options = (selected_element ? selected_element->element_options : NULL);
 
@@ -1262,6 +1423,7 @@ int main(int argc, char *argv[])
                 consolePrint("______________________________\n\n");
 
                 if (cur_menu->id == MenuId_Nsp) g_nspMenuElements[0]->userdata = title_info;
+                if (cur_menu->id == MenuId_Nsp) g_nspMenuElements[1]->userdata = title_info;
 
                 if (cur_menu->id == MenuId_Ticket) g_ticketMenuElements[0]->userdata = title_info;
 
@@ -1295,6 +1457,12 @@ int main(int argc, char *argv[])
         } else
         if (cur_menu->id == MenuId_GameCard) {
             consolePrint("For a full gamecard image: dump XCI, initial data, certificate, id set and uid.\n");
+            consolePrint("______________________________\n\n");
+        } else
+        if (cur_menu->id == MenuId_NspQueue || cur_menu->id == MenuId_NspQueueView) {
+            consolePrint("nsp queue status:\n\n");
+            consolePrint("queued items: %u\n", g_nspDumpQueueCount);
+            if (cur_menu->id == MenuId_NspQueueView) consolePrint("press a on an entry to remove it from the queue\n");
             consolePrint("______________________________\n\n");
         }
 
@@ -1382,6 +1550,10 @@ int main(int argc, char *argv[])
                 {
                     error = !titleGetUserApplicationData(app_metadata->title_id, &user_app_data);
                     if (error) consolePrint("\nfailed to get user application data for %016lX!\n", app_metadata->title_id);
+                } else
+                if (child_menu->id == MenuId_NspQueueView)
+                {
+                    updateNspQueueViewList();
                 } else
                 if (child_menu->id == MenuId_Nsp || child_menu->id == MenuId_Ticket || child_menu->id == MenuId_Nca)
                 {
@@ -1472,6 +1644,13 @@ int main(int argc, char *argv[])
             if (selected_element->task_func)
             {
                 bool show_button_prompt = true;
+                bool is_queue_management_action = (selected_element->task_func == &addNintendoSubmissionPackageToQueue ||
+                                                   selected_element->task_func == &clearNintendoSubmissionPackageQueue ||
+                                                   selected_element->task_func == &removeNintendoSubmissionPackageQueueEntry);
+                bool is_queue_management_context = ((cur_menu->id == MenuId_Nsp && cur_menu->selected == 1) ||
+                                                   (cur_menu->id == MenuId_NspQueue && cur_menu->selected == 1) ||
+                                                   (cur_menu->id == MenuId_NspQueueView));
+                bool skip_dump_path = (is_queue_management_action || is_queue_management_context);
 
                 consoleClear();
 
@@ -1491,6 +1670,11 @@ int main(int argc, char *argv[])
 
                     /* Update free space. */
                     if (!useUsbHost()) updateStorageList();
+                } else
+                if (skip_dump_path)
+                {
+                    /* Ignore result for queue-only management actions. */
+                    selected_element->task_func(selected_element->userdata);
                 } else
                 if (cur_menu->id > MenuId_Root)
                 {
@@ -1623,10 +1807,15 @@ int main(int argc, char *argv[])
             if (cur_menu->id == MenuId_Nsp)
             {
                 g_nspMenuElements[0]->userdata = NULL;
+                g_nspMenuElements[1]->userdata = NULL;
             } else
             if (cur_menu->id == MenuId_Ticket)
             {
                 g_ticketMenuElements[0]->userdata = NULL;
+            } else
+            if (cur_menu->id == MenuId_NspQueueView)
+            {
+                freeNspQueueViewList();
             } else
             if (cur_menu->id == MenuId_Nca)
             {
@@ -1728,6 +1917,10 @@ int main(int argc, char *argv[])
     freeNcaFsSectionsList();
 
     freeNcaList();
+
+    freeNspQueueViewList();
+
+    if (g_nspDumpQueue) free(g_nspDumpQueue);
 
     freeTitleList(&g_systemTitlesMenu);
     freeTitleList(&g_userTitlesMenu);
@@ -1988,6 +2181,261 @@ void updateTitleList(Menu *menu, Menu *submenu, bool is_system)
 
 end:
     if (app_metadata) free(app_metadata);
+}
+
+void freeNspQueueViewList(void)
+{
+    if (g_nspQueueViewMenuElements)
+    {
+        for(u32 i = 0; g_nspQueueViewMenuElements[i]; i++)
+        {
+            if (g_nspQueueViewMenuElements[i]->str) free(g_nspQueueViewMenuElements[i]->str);
+            if (g_nspQueueViewMenuElements[i]->userdata) free(g_nspQueueViewMenuElements[i]->userdata);
+            free(g_nspQueueViewMenuElements[i]);
+        }
+
+        free(g_nspQueueViewMenuElements);
+        g_nspQueueViewMenuElements = NULL;
+    }
+
+    g_nspQueueViewMenu.scroll = 0;
+    g_nspQueueViewMenu.selected = 0;
+    g_nspQueueViewMenu.elements = NULL;
+}
+
+void updateNspQueueViewList(void)
+{
+    u32 idx = 0;
+
+    freeNspQueueViewList();
+
+    if (!g_nspDumpQueueCount || !g_nspDumpQueue) return;
+
+    g_nspQueueViewMenuElements = calloc(g_nspDumpQueueCount + 1, sizeof(MenuElement*));
+    if (!g_nspQueueViewMenuElements) return;
+
+    for(u32 i = 0; i < g_nspDumpQueueCount; i++)
+    {
+        const NspQueueEntry *entry = &(g_nspDumpQueue[i]);
+        const char *type_str = titleGetNcmContentMetaTypeName(entry->meta_type);
+        char *label = NULL;
+        u32 *entry_idx = NULL;
+
+        g_nspQueueViewMenuElements[idx] = calloc(1, sizeof(MenuElement));
+        if (!g_nspQueueViewMenuElements[idx]) continue;
+
+        label = calloc(1, 0x400);
+        entry_idx = calloc(1, sizeof(u32));
+
+        if (!label || !entry_idx)
+        {
+            if (label) free(label);
+            if (entry_idx) free(entry_idx);
+            free(g_nspQueueViewMenuElements[idx]);
+            g_nspQueueViewMenuElements[idx] = NULL;
+            continue;
+        }
+
+        *entry_idx = i;
+
+        snprintf(label, 0x400, "remove: %s [%016lX] (%s)", entry->name, entry->title_id, (type_str ? type_str : "unknown"));
+
+        g_nspQueueViewMenuElements[idx]->str = label;
+        g_nspQueueViewMenuElements[idx]->child_menu = NULL;
+        g_nspQueueViewMenuElements[idx]->task_func = &removeNintendoSubmissionPackageQueueEntry;
+        g_nspQueueViewMenuElements[idx]->element_options = NULL;
+        g_nspQueueViewMenuElements[idx]->userdata = entry_idx;
+
+        idx++;
+    }
+
+    if (!idx)
+    {
+        freeNspQueueViewList();
+        return;
+    }
+
+    g_nspQueueViewMenu.elements = g_nspQueueViewMenuElements;
+}
+
+static bool addNintendoSubmissionPackageToQueue(void *userdata)
+{
+    if (!userdata) return false;
+
+    TitleInfo *title_info = (TitleInfo*)userdata;
+
+    if (title_info->meta_key.type < NcmContentMetaType_Application || title_info->meta_key.type > NcmContentMetaType_DataPatch)
+    {
+        consolePrint("invalid title type for nsp queue\n");
+        return false;
+    }
+
+    for(u32 i = 0; i < g_nspDumpQueueCount; i++)
+    {
+        NspQueueEntry *entry = &(g_nspDumpQueue[i]);
+        if (entry->title_id == title_info->meta_key.id && entry->meta_type == title_info->meta_key.type)
+        {
+            consolePrint("title already queued\n");
+            return false;
+        }
+    }
+
+    NspQueueEntry *new_queue = realloc(g_nspDumpQueue, (g_nspDumpQueueCount + 1) * sizeof(NspQueueEntry));
+    if (!new_queue)
+    {
+        consolePrint("failed to expand nsp queue\n");
+        return false;
+    }
+
+    g_nspDumpQueue = new_queue;
+
+    NspQueueEntry *new_entry = &(g_nspDumpQueue[g_nspDumpQueueCount]);
+    memset(new_entry, 0, sizeof(NspQueueEntry));
+
+    new_entry->title_id = title_info->meta_key.id;
+    new_entry->meta_type = title_info->meta_key.type;
+    new_entry->is_system = (title_info->storage_id == NcmStorageId_BuiltInSystem);
+
+    const char *name = (title_info->app_metadata && title_info->app_metadata->name[0] ? title_info->app_metadata->name : "unknown");
+    snprintf(new_entry->name, sizeof(new_entry->name), "%s", name);
+
+    g_nspDumpQueueCount++;
+
+    consolePrint("queued title %016lX (%u item(s) total)\n", new_entry->title_id, g_nspDumpQueueCount);
+
+    return true;
+}
+
+static bool startNintendoSubmissionPackageQueue(void *userdata)
+{
+    NX_IGNORE_ARG(userdata);
+
+    if (!g_nspDumpQueueCount || !g_nspDumpQueue)
+    {
+        consolePrint("nsp queue is empty\n");
+        return false;
+    }
+
+    u32 success_count = 0, fail_count = 0;
+
+    for(u32 i = 0; i < g_nspDumpQueueCount; i++)
+    {
+        NspQueueEntry *entry = &(g_nspDumpQueue[i]);
+        u32 title_idx = 0, title_count = 0;
+
+        TitleInfo *title_info_root = titleGetTitleInfoEntryFromStorageByTitleId(entry->is_system ? NcmStorageId_BuiltInSystem : NcmStorageId_Any, entry->title_id);
+        TitleInfo *title_info = title_info_root;
+
+        if (!title_info_root)
+        {
+            consolePrint("[%u/%u] failed to resolve %016lX\n", i + 1, g_nspDumpQueueCount, entry->title_id);
+            fail_count++;
+            continue;
+        }
+
+        title_info = getLatestTitleInfo(title_info, &title_idx, &title_count);
+
+        if (title_info->meta_key.type != entry->meta_type)
+        {
+            TitleInfo *cur_info = title_info;
+            bool found = false;
+
+            while(cur_info)
+            {
+                if (cur_info->meta_key.type == entry->meta_type)
+                {
+                    title_info = cur_info;
+                    found = true;
+                    break;
+                }
+
+                cur_info = cur_info->next;
+            }
+
+            if (!found)
+            {
+                consolePrint("[%u/%u] missing expected type for %016lX\n", i + 1, g_nspDumpQueueCount, entry->title_id);
+                titleFreeTitleInfo(&title_info_root);
+                fail_count++;
+                continue;
+            }
+        }
+
+        consoleClear();
+        consolePrint("queued nsp dump %u/%u\n", i + 1, g_nspDumpQueueCount);
+
+        bool ret = saveNintendoSubmissionPackage(title_info);
+
+        titleFreeTitleInfo(&title_info_root);
+
+        if (ret)
+        {
+            success_count++;
+        } else {
+            fail_count++;
+        }
+
+        if (!g_appletStatus) break;
+    }
+
+    consolePrint("\nqueue done: %u succeeded, %u failed\n", success_count, fail_count);
+
+    return (success_count > 0 && !fail_count);
+}
+
+static bool clearNintendoSubmissionPackageQueue(void *userdata)
+{
+    NX_IGNORE_ARG(userdata);
+
+    if (!g_nspDumpQueueCount || !g_nspDumpQueue)
+    {
+        consolePrint("nsp queue is already empty\n");
+        return false;
+    }
+
+    consolePrint("are you sure you want to clear the nsp queue?\n");
+    consolePrint("press a to proceed, or b to cancel\n\n");
+
+    u64 btn_down = utilsWaitForButtonPress(HidNpadButton_A | HidNpadButton_B);
+    if (btn_down & HidNpadButton_A)
+    {
+        free(g_nspDumpQueue);
+        g_nspDumpQueue = NULL;
+        g_nspDumpQueueCount = 0;
+
+        freeNspQueueViewList();
+
+        consolePrint("nsp queue cleared\n");
+    }
+
+    return false;
+}
+
+static bool removeNintendoSubmissionPackageQueueEntry(void *userdata)
+{
+    if (!userdata || !g_nspDumpQueueCount || !g_nspDumpQueue) return false;
+
+    u32 idx = *((u32*)userdata);
+    if (idx >= g_nspDumpQueueCount) return false;
+
+    if (idx < (g_nspDumpQueueCount - 1)) memmove(&(g_nspDumpQueue[idx]), &(g_nspDumpQueue[idx + 1]), (g_nspDumpQueueCount - idx - 1) * sizeof(NspQueueEntry));
+
+    g_nspDumpQueueCount--;
+
+    if (!g_nspDumpQueueCount)
+    {
+        free(g_nspDumpQueue);
+        g_nspDumpQueue = NULL;
+    } else {
+        NspQueueEntry *new_queue = realloc(g_nspDumpQueue, g_nspDumpQueueCount * sizeof(NspQueueEntry));
+        if (new_queue) g_nspDumpQueue = new_queue;
+    }
+
+    updateNspQueueViewList();
+
+    consolePrint("queue entry removed\n");
+
+    return false;
 }
 
 static TitleInfo *getLatestTitleInfo(TitleInfo *title_info, u32 *out_idx, u32 *out_count)

--- a/code_templates/nxdt_rw_poc.c
+++ b/code_templates/nxdt_rw_poc.c
@@ -1412,7 +1412,8 @@ int main(int argc, char *argv[])
         if ((cur_menu->id == MenuId_UserTitles || cur_menu->id == MenuId_SystemTitles) && element_count)
         {
             consolePrint("press y to dump csv with title info to the sd card\n");
-            consolePrint("press zl + zr to add all titles to the nsp dump queue\n");
+            if (cur_menu->id == MenuId_UserTitles) 
+                consolePrint("press zl + zr to add all titles to the nsp dump queue\n");
         }
         consolePrint("use the sticks to scroll faster\n");
         consolePrint("press + to exit\n");
@@ -1972,7 +1973,7 @@ int main(int argc, char *argv[])
                 g_ncaMenuElements[i]->task_func = (g_ncaMenuRawMode ? &saveNintendoContentArchive : NULL);
             }
         } else
-        if ((btn_down & (HidNpadButton_ZL | HidNpadButton_ZR)) && cur_menu->id == MenuId_UserTitles && element_count)
+        if ((btn_down & HidNpadButton_ZL) && (btn_down & HidNpadButton_ZR) && cur_menu->id == MenuId_UserTitles && element_count)
         {
             addAllUserTitlesToNspDumpQueueViewList(element_count);
         } else

--- a/code_templates/nxdt_rw_poc.c
+++ b/code_templates/nxdt_rw_poc.c
@@ -1698,6 +1698,15 @@ int main(int argc, char *argv[])
             if (selected_element->task_func)
             {
                 bool show_button_prompt = true;
+                /* For queue management actions, we want to show the button prompt 
+                and wait for a button press before going back to the queue view, 
+                but we don't want to wait for USB or show the "please wait" message 
+                since these actions are usually very fast and waiting for USB or 
+                showing the message could be disruptive. */
+                bool is_queue_management_action = (selected_element->task_func == &addNintendoSubmissionPackageToQueue ||
+                                                   selected_element->task_func == &addAllAvailableNintendoSubmissionPackagesToQueue ||
+                                                   selected_element->task_func == &clearNintendoSubmissionPackageQueue ||
+                                                   selected_element->task_func == &removeNintendoSubmissionPackageQueueEntry);
 
                 consoleClear();
 
@@ -1718,7 +1727,7 @@ int main(int argc, char *argv[])
                     /* Update free space. */
                     if (!useUsbHost()) updateStorageList();
                 } else
-                if (cur_menu->id > MenuId_Root)
+                if (cur_menu->id > MenuId_Root && !is_queue_management_action)
                 {
                     /* Wait for USB session (if needed). */
                     if (useUsbHost() && !waitForUsb())
@@ -2294,9 +2303,9 @@ void updateNspQueueViewList(void)
 
         *entry_idx = i;
 
-        g_nspQueueViewMenuElements[idx]->str = label;
-        g_nspQueueViewMenuElements[idx]->task_func = &removeNintendoSubmissionPackageQueueEntry;
-        g_nspQueueViewMenuElements[idx]->userdata = entry_idx;
+        elements[idx]->str = label;
+        elements[idx]->task_func = &removeNintendoSubmissionPackageQueueEntry;
+        elements[idx]->userdata = entry_idx;
 
         idx++;
     }

--- a/code_templates/nxdt_rw_poc.c
+++ b/code_templates/nxdt_rw_poc.c
@@ -243,6 +243,7 @@ static bool browseGameCardHfsPartition(void *userdata);
 static bool saveConsoleLafwBlob(void *userdata);
 
 static bool addNintendoSubmissionPackageToQueue(void *userdata);
+static bool addAllAvailableNintendoSubmissionPackagesToQueue(void *userdata);
 static bool startNintendoSubmissionPackageQueue(void *userdata);
 static bool clearNintendoSubmissionPackageQueue(void *userdata);
 static bool removeNintendoSubmissionPackageQueueEntry(void *userdata);
@@ -1087,6 +1088,13 @@ static MenuElement *g_titleTypesMenuElements[] = {
         .element_options = NULL,
         .userdata = &g_metaTypeAOCPatch
     },
+    &(MenuElement){
+        .str = "add all available to nsp queue",
+        .child_menu = NULL,
+        .task_func = &addAllAvailableNintendoSubmissionPackagesToQueue,
+        .element_options = NULL,
+        .userdata = NULL // Dynamically set to a TitleUserApplicationData object when needed
+    },
     NULL
 };
 
@@ -1368,6 +1376,8 @@ int main(int argc, char *argv[])
             g_titleTypesMenuElements[2]->child_menu = g_titleTypesMenuElements[3]->child_menu = (child_id == MenuId_NspTitleTypes ? &g_nspMenu : \
                                                                                                 (child_id == MenuId_TicketTitleTypes ? &g_ticketMenu : \
                                                                                                 (child_id == MenuId_NcaTitleTypes ? &g_ncaMenu : NULL)));
+
+            g_titleTypesMenuElements[4]->userdata = (child_id == MenuId_NspTitleTypes ? &user_app_data : NULL);
         }
 
         consoleClear();
@@ -1645,6 +1655,7 @@ int main(int argc, char *argv[])
             {
                 bool show_button_prompt = true;
                 bool is_queue_management_action = (selected_element->task_func == &addNintendoSubmissionPackageToQueue ||
+                                                   selected_element->task_func == &addAllAvailableNintendoSubmissionPackagesToQueue ||
                                                    selected_element->task_func == &clearNintendoSubmissionPackageQueue ||
                                                    selected_element->task_func == &removeNintendoSubmissionPackageQueueEntry);
                 bool is_queue_management_context = ((cur_menu->id == MenuId_Nsp && cur_menu->selected == 1) ||
@@ -1798,6 +1809,7 @@ int main(int argc, char *argv[])
                 titleFreeUserApplicationData(&user_app_data);
                 g_titleTypesMenuElements[0]->child_menu = g_titleTypesMenuElements[1]->child_menu = \
                 g_titleTypesMenuElements[2]->child_menu = g_titleTypesMenuElements[3]->child_menu = NULL;
+                g_titleTypesMenuElements[4]->userdata = NULL;
             } else
             if (cur_menu->id == MenuId_NspTitleTypes || cur_menu->id == MenuId_TicketTitleTypes || cur_menu->id == MenuId_NcaTitleTypes)
             {
@@ -2306,6 +2318,91 @@ static bool addNintendoSubmissionPackageToQueue(void *userdata)
     return true;
 }
 
+static bool addAllAvailableNintendoSubmissionPackagesToQueue(void *userdata)
+{
+    TitleUserApplicationData *user_app_data = (TitleUserApplicationData*)userdata;
+    if (!user_app_data)
+    {
+        consolePrint("invalid user application data\n");
+        return false;
+    }
+
+    consolePrint("warning: this will queue all available nsp dump targets for the selected title\n");
+    consolePrint("including base app, latest update, all dlc and dlc updates\n");
+    consolePrint("press a to proceed, or b to cancel\n\n");
+
+    u64 btn_down = utilsWaitForButtonPress(HidNpadButton_A | HidNpadButton_B);
+    if (!(btn_down & HidNpadButton_A))
+    {
+        consolePrint("bulk queue add cancelled\n");
+        return false;
+    }
+
+    u32 queued_before = g_nspDumpQueueCount;
+
+    if (user_app_data->app_info) addNintendoSubmissionPackageToQueue(user_app_data->app_info);
+
+    if (user_app_data->patch_info)
+    {
+        u32 patch_idx = 0, patch_count = 0;
+        TitleInfo *latest_patch = getLatestTitleInfo(user_app_data->patch_info, &patch_idx, &patch_count);
+        if (latest_patch) addNintendoSubmissionPackageToQueue(latest_patch);
+    }
+
+    for(TitleInfo *cur = user_app_data->aoc_info; cur; cur = cur->next)
+    {
+        addNintendoSubmissionPackageToQueue(cur);
+    }
+
+    if (user_app_data->aoc_patch_info)
+    {
+        typedef struct {
+            u64 id;
+            TitleInfo *latest;
+        } LatestPatchEntry;
+
+        LatestPatchEntry *latest_entries = NULL;
+        u32 latest_count = 0;
+
+        for(TitleInfo *cur = user_app_data->aoc_patch_info; cur; cur = cur->next)
+        {
+            bool found = false;
+
+            for(u32 i = 0; i < latest_count; i++)
+            {
+                if (latest_entries[i].id == cur->meta_key.id)
+                {
+                    found = true;
+                    if (cur->version.value > latest_entries[i].latest->version.value) latest_entries[i].latest = cur;
+                    break;
+                }
+            }
+
+            if (!found)
+            {
+                LatestPatchEntry *tmp = realloc(latest_entries, (latest_count + 1) * sizeof(LatestPatchEntry));
+                if (!tmp) break;
+
+                latest_entries = tmp;
+                latest_entries[latest_count].id = cur->meta_key.id;
+                latest_entries[latest_count].latest = cur;
+                latest_count++;
+            }
+        }
+
+        for(u32 i = 0; i < latest_count; i++) addNintendoSubmissionPackageToQueue(latest_entries[i].latest);
+
+        if (latest_entries) free(latest_entries);
+    }
+
+    u32 queued_after = g_nspDumpQueueCount;
+    u32 added_count = (queued_after >= queued_before ? (queued_after - queued_before) : 0);
+
+    consolePrint("bulk queue add finished: %u item(s) added\n", added_count);
+
+    return (added_count > 0);
+}
+
 static bool startNintendoSubmissionPackageQueue(void *userdata)
 {
     NX_IGNORE_ARG(userdata);
@@ -2318,7 +2415,7 @@ static bool startNintendoSubmissionPackageQueue(void *userdata)
 
     u32 success_count = 0, fail_count = 0;
 
-    for(u32 i = 0; i < g_nspDumpQueueCount; i++)
+    for(u32 i = 0; i < g_nspDumpQueueCount;)
     {
         NspQueueEntry *entry = &(g_nspDumpQueue[i]);
         u32 title_idx = 0, title_count = 0;
@@ -2371,14 +2468,32 @@ static bool startNintendoSubmissionPackageQueue(void *userdata)
         if (ret)
         {
             success_count++;
+
+            if (i < (g_nspDumpQueueCount - 1)) memmove(&(g_nspDumpQueue[i]), &(g_nspDumpQueue[i + 1]), (g_nspDumpQueueCount - i - 1) * sizeof(NspQueueEntry));
+
+            g_nspDumpQueueCount--;
+
+            if (!g_nspDumpQueueCount)
+            {
+                free(g_nspDumpQueue);
+                g_nspDumpQueue = NULL;
+                break;
+            }
+
+            NspQueueEntry *new_queue = realloc(g_nspDumpQueue, g_nspDumpQueueCount * sizeof(NspQueueEntry));
+            if (new_queue) g_nspDumpQueue = new_queue;
         } else {
             fail_count++;
+            i++;
         }
 
         if (!g_appletStatus) break;
     }
 
+    updateNspQueueViewList();
+
     consolePrint("\nqueue done: %u succeeded, %u failed\n", success_count, fail_count);
+    consolePrint("queue remaining: %u\n", g_nspDumpQueueCount);
 
     return (success_count > 0 && !fail_count);
 }

--- a/code_templates/nxdt_rw_poc.c
+++ b/code_templates/nxdt_rw_poc.c
@@ -204,12 +204,12 @@ void updateNcaBasePatchList(TitleUserApplicationData *user_app_data, TitleInfo *
 
 void freeNspQueueViewList(void);
 void updateNspQueueViewList(void);
+
 void freeNspDumpQueue(void);
-static bool addNspQueueEntry(TitleInfo *title_info);
-static void removeNspQueueEntryByIndex(u32 idx);
-static bool isQueueEligibleTitle(const TitleInfo *title_info);
-static bool shouldPreferTitleForQueue(const TitleInfo *candidate, const TitleInfo *current);
-static TitleInfo *getBestQueueCandidateFromChain(TitleInfo *title_info);
+static bool addNspDumpQueueEntry(TitleInfo *title_info);
+static void removeNspDumpQueueEntryByIndex(u32 idx);
+
+static inline bool isTitleStorageMediumEligibleForNspDumpQueue(const TitleInfo *title_info);
 
 NX_INLINE bool useUsbHost(void);
 
@@ -827,6 +827,7 @@ static Menu g_nspMenu = {
 
 static MenuElement **g_nspQueueViewMenuElements = NULL;
 
+// Dynamically populated using g_nspQueueViewMenuElements.
 static Menu g_nspQueueViewMenu = {
     .id = MenuId_NspQueueView,
     .parent = NULL,
@@ -1089,7 +1090,7 @@ static MenuElement *g_nspTitleTypesMenuElements[] = {
         .userdata = &g_metaTypeAOCPatch
     },
     &(MenuElement){
-        .str = "add all available to nsp queue",
+        .str = "add all available titles to nsp queue",
         .child_menu = NULL,
         .task_func = &addAllAvailableNintendoSubmissionPackagesToQueue,
         .element_options = NULL,
@@ -1385,6 +1386,7 @@ int main(int argc, char *argv[])
 
     while(appletMainLoop())
     {
+        /* Clamp selection on NSP queue list because it could have been changed. */
         if (cur_menu->id == MenuId_NspQueueView)
         {
             element_count = menuGetElementCount(cur_menu);
@@ -1409,10 +1411,10 @@ int main(int argc, char *argv[])
             g_nspTitleTypesMenuElements[0]->child_menu = g_nspTitleTypesMenuElements[1]->child_menu = \
             g_nspTitleTypesMenuElements[2]->child_menu = g_nspTitleTypesMenuElements[3]->child_menu = target_menu;
 
+            g_nspTitleTypesMenuElements[4]->userdata = (child_id == MenuId_NspTitleTypes ? &user_app_data : NULL);
+
             g_titleTypesMenuElements[0]->child_menu = g_titleTypesMenuElements[1]->child_menu = \
             g_titleTypesMenuElements[2]->child_menu = g_titleTypesMenuElements[3]->child_menu = target_menu;
-
-            g_nspTitleTypesMenuElements[4]->userdata = (child_id == MenuId_NspTitleTypes ? &user_app_data : NULL);
         }
 
         consoleClear();
@@ -1467,8 +1469,7 @@ int main(int argc, char *argv[])
                 consolePrint("size: %s\n", title_info->size_str);
                 consolePrint("______________________________\n\n");
 
-                if (cur_menu->id == MenuId_Nsp) g_nspMenuElements[0]->userdata = title_info;
-                if (cur_menu->id == MenuId_Nsp) g_nspMenuElements[1]->userdata = title_info;
+                if (cur_menu->id == MenuId_Nsp) g_nspMenuElements[0]->userdata = g_nspMenuElements[1]->userdata = title_info;
 
                 if (cur_menu->id == MenuId_Ticket) g_ticketMenuElements[0]->userdata = title_info;
 
@@ -1500,11 +1501,13 @@ int main(int argc, char *argv[])
                 }
             }
         } else
-        if (cur_menu->id == MenuId_GameCard) {
+        if (cur_menu->id == MenuId_GameCard)
+        {
             consolePrint("For a full gamecard image: dump XCI, initial data, certificate, id set and uid.\n");
             consolePrint("______________________________\n\n");
         } else
-        if (cur_menu->id == MenuId_NspQueue || cur_menu->id == MenuId_NspQueueView) {
+        if (cur_menu->id == MenuId_NspQueue || cur_menu->id == MenuId_NspQueueView)
+        {
             consolePrint("nsp queue status:\n\n");
             consolePrint("queued items: %u\n", g_nspDumpQueueCount);
             if (cur_menu->id == MenuId_NspQueueView) consolePrint("press a on an entry to remove it from the queue\n");
@@ -1596,10 +1599,6 @@ int main(int argc, char *argv[])
                     error = !titleGetUserApplicationData(app_metadata->title_id, &user_app_data);
                     if (error) consolePrint("\nfailed to get user application data for %016lX!\n", app_metadata->title_id);
                 } else
-                if (child_menu->id == MenuId_NspQueueView)
-                {
-                    updateNspQueueViewList();
-                } else
                 if (child_menu->id == MenuId_Nsp || child_menu->id == MenuId_Ticket || child_menu->id == MenuId_Nca)
                 {
                     u32 title_type = (cur_menu->id != MenuId_SystemTitles ? *((u32*)selected_element->userdata) : NcmContentMetaType_Unknown);
@@ -1626,7 +1625,13 @@ int main(int argc, char *argv[])
 
                     if (title_info)
                     {
-                        title_info = getLatestTitleInfo(title_info, &title_info_idx, &title_info_count);
+                        if (title_info->meta_key.type == NcmContentMetaType_Patch || title_info->meta_key.type == NcmContentMetaType_DataPatch)
+                        {
+                            title_info = getLatestTitleInfo(title_info, &title_info_idx, &title_info_count);
+                        } else {
+                            title_info_idx = 0;
+                            title_info_count = titleGetCountFromInfoBlock(title_info);
+                        }
 
                         if (child_menu->id == MenuId_Nca)
                         {
@@ -1673,6 +1678,10 @@ int main(int argc, char *argv[])
                         consolePrint("can't dump an invalid nca fs section!\n");
                         error = true;
                     }
+                } else
+                if (child_menu->id == MenuId_NspQueueView)
+                {
+                    updateNspQueueViewList();
                 }
 
                 if (!error)
@@ -1689,10 +1698,6 @@ int main(int argc, char *argv[])
             if (selected_element->task_func)
             {
                 bool show_button_prompt = true;
-                bool is_queue_management_action = (selected_element->task_func == &addNintendoSubmissionPackageToQueue ||
-                                                   selected_element->task_func == &addAllAvailableNintendoSubmissionPackagesToQueue ||
-                                                   selected_element->task_func == &clearNintendoSubmissionPackageQueue ||
-                                                   selected_element->task_func == &removeNintendoSubmissionPackageQueueEntry);
 
                 consoleClear();
 
@@ -1712,11 +1717,6 @@ int main(int argc, char *argv[])
 
                     /* Update free space. */
                     if (!useUsbHost()) updateStorageList();
-                } else
-                if (is_queue_management_action)
-                {
-                    /* Ignore result for queue-only management actions. */
-                    selected_element->task_func(selected_element->userdata);
                 } else
                 if (cur_menu->id > MenuId_Root)
                 {
@@ -1838,8 +1838,10 @@ int main(int argc, char *argv[])
             if (cur_menu->id == MenuId_UserTitlesSubMenu)
             {
                 titleFreeUserApplicationData(&user_app_data);
+
                 g_nspTitleTypesMenuElements[0]->child_menu = g_nspTitleTypesMenuElements[1]->child_menu = \
                 g_nspTitleTypesMenuElements[2]->child_menu = g_nspTitleTypesMenuElements[3]->child_menu = NULL;
+
                 g_nspTitleTypesMenuElements[4]->userdata = NULL;
 
                 g_titleTypesMenuElements[0]->child_menu = g_titleTypesMenuElements[1]->child_menu = \
@@ -1859,10 +1861,6 @@ int main(int argc, char *argv[])
             {
                 g_ticketMenuElements[0]->userdata = NULL;
             } else
-            if (cur_menu->id == MenuId_NspQueueView)
-            {
-                freeNspQueueViewList();
-            } else
             if (cur_menu->id == MenuId_Nca)
             {
                 freeNcaList();
@@ -1880,6 +1878,10 @@ int main(int argc, char *argv[])
             if (cur_menu->id == MenuId_NcaFsSectionsSubMenu)
             {
                 freeNcaBasePatchList();
+            } else
+            if (cur_menu->id == MenuId_NspQueueView)
+            {
+                freeNspQueueViewList();
             }
 
             cur_menu = cur_menu->parent;
@@ -2204,6 +2206,7 @@ void updateTitleList(Menu *menu, Menu *submenu, bool is_system)
 
     /* Allocate buffer. */
     elements = calloc(app_count + 1, sizeof(MenuElement*)); // NULL terminator
+    if (!elements) goto end;
 
     /* Generate menu elements. */
     for(u32 i = 0; i < app_count; i++)
@@ -2252,69 +2255,60 @@ void freeNspQueueViewList(void)
 void updateNspQueueViewList(void)
 {
     u32 idx = 0;
+    MenuElement **elements = NULL;
 
+    /* Free all previously allocated data. */
     freeNspQueueViewList();
 
+    /* Don't proceed any further if there's no actual queue to work with. */
     if (!g_nspDumpQueueCount || !g_nspDumpQueue) return;
 
-    g_nspQueueViewMenuElements = calloc(g_nspDumpQueueCount + 1, sizeof(MenuElement*));
-    if (!g_nspQueueViewMenuElements) return;
+    /* Allocate buffer. */
+    elements = calloc(g_nspDumpQueueCount + 1, sizeof(MenuElement*)); // NULL terminator
+    if (!elements) return;
 
+    /* Generate menu elements. */
     for(u32 i = 0; i < g_nspDumpQueueCount; i++)
     {
         const TitleInfo *title_info = g_nspDumpQueue[i];
-        const char *type_str = (title_info ? titleGetNcmContentMetaTypeName(title_info->meta_key.type) : NULL);
+        if (!title_info) continue;
+
         char *label = NULL;
         u32 *entry_idx = NULL;
 
-        g_nspQueueViewMenuElements[idx] = calloc(1, sizeof(MenuElement));
-        if (!g_nspQueueViewMenuElements[idx]) continue;
+        if (!elements[idx])
+        {
+            elements[idx] = calloc(1, sizeof(MenuElement));
+            if (!elements[idx]) continue;
+        }
 
-        label = calloc(1, 0x400);
+        label = titleGenerateFileName(title_info, TitleNamingConvention_Full, TitleFileNameIllegalCharReplaceType_IllegalFsChars);
         entry_idx = calloc(1, sizeof(u32));
 
         if (!label || !entry_idx)
         {
             if (label) free(label);
             if (entry_idx) free(entry_idx);
-            free(g_nspQueueViewMenuElements[idx]);
-            g_nspQueueViewMenuElements[idx] = NULL;
             continue;
         }
 
         *entry_idx = i;
 
-        snprintf(label, 0x400, "remove: %s [%016lX] (%s)", \
-             (title_info && title_info->app_metadata && title_info->app_metadata->name[0] ? title_info->app_metadata->name : "unknown"), \
-             (title_info ? title_info->meta_key.id : 0), \
-             (type_str ? type_str : "unknown"));
-
         g_nspQueueViewMenuElements[idx]->str = label;
-        g_nspQueueViewMenuElements[idx]->child_menu = NULL;
         g_nspQueueViewMenuElements[idx]->task_func = &removeNintendoSubmissionPackageQueueEntry;
-        g_nspQueueViewMenuElements[idx]->element_options = NULL;
         g_nspQueueViewMenuElements[idx]->userdata = entry_idx;
 
         idx++;
     }
 
-    if (!idx)
-    {
-        freeNspQueueViewList();
-        return;
-    }
-
-    g_nspQueueViewMenu.elements = g_nspQueueViewMenuElements;
+    g_nspQueueViewMenu.elements = g_nspQueueViewMenuElements = elements;
 }
 
 void freeNspDumpQueue(void)
 {
     if (g_nspDumpQueue)
     {
-        for(u32 i = 0; i < g_nspDumpQueueCount; i++)
-        {
-            if (g_nspDumpQueue[i]) titleFreeTitleInfo(&(g_nspDumpQueue[i]));
-        }
+        for(u32 i = 0; i < g_nspDumpQueueCount; i++) titleFreeTitleInfo(&(g_nspDumpQueue[i]));
 
         free(g_nspDumpQueue);
         g_nspDumpQueue = NULL;
@@ -2324,13 +2318,14 @@ void freeNspDumpQueue(void)
     g_nspDumpQueueCapacity = 0;
 }
 
-static bool addNspQueueEntry(TitleInfo *title_info)
+static bool addNspDumpQueueEntry(TitleInfo *title_info)
 {
     if (!title_info) return false;
 
     if (g_nspDumpQueueCount >= g_nspDumpQueueCapacity)
     {
-        u32 new_capacity = (g_nspDumpQueueCapacity ? (g_nspDumpQueueCapacity * 2) : 8);
+        size_t new_capacity = (g_nspDumpQueueCapacity ? (g_nspDumpQueueCapacity * 2) : 8);
+
         TitleInfo **new_queue = realloc(g_nspDumpQueue, new_capacity * sizeof(TitleInfo*));
         if (!new_queue) return false;
 
@@ -2342,52 +2337,16 @@ static bool addNspQueueEntry(TitleInfo *title_info)
     return true;
 }
 
-static bool isQueueEligibleTitle(const TitleInfo *title_info)
+static inline bool isTitleStorageMediumEligibleForNspDumpQueue(const TitleInfo *title_info)
 {
-    if (!title_info) return false;
-
-    return (title_info->storage_id == NcmStorageId_BuiltInUser || title_info->storage_id == NcmStorageId_SdCard);
+    return (title_info && (title_info->storage_id == NcmStorageId_GameCard || title_info->storage_id == NcmStorageId_BuiltInUser || title_info->storage_id == NcmStorageId_SdCard));
 }
 
-static bool shouldPreferTitleForQueue(const TitleInfo *candidate, const TitleInfo *current)
-{
-    if (!candidate) return false;
-    if (!current) return true;
-
-    bool candidate_eligible = isQueueEligibleTitle(candidate);
-    bool current_eligible = isQueueEligibleTitle(current);
-
-    if (candidate_eligible && !current_eligible) return true;
-    if (!candidate_eligible) return false;
-
-    if (candidate->version.value > current->version.value) return true;
-    if (candidate->version.value < current->version.value) return false;
-
-    return (candidate->storage_id == NcmStorageId_SdCard && current->storage_id == NcmStorageId_BuiltInUser);
-}
-
-static TitleInfo *getBestQueueCandidateFromChain(TitleInfo *title_info)
-{
-    if (!title_info) return NULL;
-
-    TitleInfo *best = NULL;
-
-    TitleInfo *cur = title_info;
-    while(cur->previous) cur = cur->previous;
-
-    for(; cur; cur = cur->next)
-    {
-        if (shouldPreferTitleForQueue(cur, best)) best = cur;
-    }
-
-    return best;
-}
-
-static void removeNspQueueEntryByIndex(u32 idx)
+static void removeNspDumpQueueEntryByIndex(u32 idx)
 {
     if (!g_nspDumpQueue || idx >= g_nspDumpQueueCount) return;
 
-    if (g_nspDumpQueue[idx]) titleFreeTitleInfo(&(g_nspDumpQueue[idx]));
+    titleFreeTitleInfo(&(g_nspDumpQueue[idx]));
 
     if (idx < (g_nspDumpQueueCount - 1)) memmove(&(g_nspDumpQueue[idx]), &(g_nspDumpQueue[idx + 1]), (g_nspDumpQueueCount - idx - 1) * sizeof(TitleInfo*));
 
@@ -2405,64 +2364,61 @@ static bool addNintendoSubmissionPackageToQueue(void *userdata)
 {
     if (!userdata) return false;
 
-    TitleInfo *title_info = (TitleInfo*)userdata;
-    TitleInfo *queue_title_info = NULL;
+    TitleInfo *title_info = NULL;
+    bool success = false;
 
-    if (!isQueueEligibleTitle(title_info))
+    title_info = titleDuplicateTitleInfo((TitleInfo*)userdata, false);
+    if (!title_info)
     {
-        consolePrint("queue only supports user-installed titles (nand/sd)\n");
-        return false;
+        consolePrint("failed to duplicate title info for queue\n");
+        goto end;
+    }
+
+    if (!isTitleStorageMediumEligibleForNspDumpQueue(title_info))
+    {
+        consolePrint("queue only supports emmc, sd card and/or gamecard titles\n");
+        goto end;
     }
 
     if (title_info->meta_key.type < NcmContentMetaType_Application || title_info->meta_key.type > NcmContentMetaType_DataPatch || title_info->meta_key.type == NcmContentMetaType_Delta)
     {
         consolePrint("invalid title type for nsp queue\n");
-        return false;
+        goto end;
     }
 
     for(u32 i = 0; i < g_nspDumpQueueCount; i++)
     {
         TitleInfo *entry = g_nspDumpQueue[i];
-        if (entry && entry->meta_key.id == title_info->meta_key.id && entry->meta_key.type == title_info->meta_key.type)
+        if (!entry || entry->meta_key.id != title_info->meta_key.id || entry->meta_key.type != title_info->meta_key.type) continue;
+
+        if (entry->version.value >= title_info->version.value)
         {
-            if (!shouldPreferTitleForQueue(title_info, entry))
-            {
-                consolePrint("title already queued\n");
-                return false;
-            }
-
-            queue_title_info = titleDuplicateTitleInfoEntry(title_info);
-            if (!queue_title_info)
-            {
-                consolePrint("failed to duplicate title info for queue\n");
-                return false;
-            }
-
-            titleFreeTitleInfo(&(g_nspDumpQueue[i]));
-            g_nspDumpQueue[i] = queue_title_info;
-
-            consolePrint("updated queued title %016lX to a newer preferred entry\n", title_info->meta_key.id);
-            return true;
+            consolePrint("title %016lX with equal or greater version already queued (v%u >= v%u)\n", entry->meta_key.id, entry->version.value, title_info->version.value);
+            goto end;
         }
+
+        consolePrint("updating queued title %016lX to a newer preferred entry (v%u -> v%u)\n", entry->meta_key.id, entry->version.value, title_info->version.value);
+
+        titleFreeTitleInfo(&(g_nspDumpQueue[i]));
+        g_nspDumpQueue[i] = title_info;
+        success = true;
+
+        goto end;
     }
 
-    queue_title_info = titleDuplicateTitleInfoEntry(title_info);
-    if (!queue_title_info)
+    if (!addNspDumpQueueEntry(title_info))
     {
-        consolePrint("failed to duplicate title info for queue\n");
-        return false;
-    }
-
-    if (!addNspQueueEntry(queue_title_info))
-    {
-        titleFreeTitleInfo(&queue_title_info);
         consolePrint("failed to expand nsp queue\n");
-        return false;
+        goto end;
     }
 
-    consolePrint("queued title %016lX (%u item(s) total)\n", title_info->meta_key.id, g_nspDumpQueueCount);
+    consolePrint("queued %s title %016lX v%u (%u item[s] total)\n", titleGetNcmStorageIdName(title_info->storage_id), title_info->meta_key.id, title_info->meta_key.version, g_nspDumpQueueCount);
+    success = true;
 
-    return true;
+end:
+    if (!success) titleFreeTitleInfo(&title_info);
+
+    return success;
 }
 
 static bool addAllAvailableNintendoSubmissionPackagesToQueue(void *userdata)
@@ -2474,119 +2430,53 @@ static bool addAllAvailableNintendoSubmissionPackagesToQueue(void *userdata)
         return false;
     }
 
-    consolePrint("warning: this will queue all available nsp dump targets for the selected title\n");
-    consolePrint("including base app, latest update, all dlc and dlc updates\n");
+    consolePrint("warning: this will queue all available nsp dump targets for the selected user\n");
+    consolePrint("title entry, including base app, latest update, all dlc and dlc updates\n");
     consolePrint("press a to proceed, or b to cancel\n\n");
 
     u64 btn_down = utilsWaitForButtonPress(HidNpadButton_A | HidNpadButton_B);
-    if (!(btn_down & HidNpadButton_A))
+    if (btn_down & HidNpadButton_B)
     {
         consolePrint("bulk queue add cancelled\n");
         return false;
     }
 
-    u32 queued_before = g_nspDumpQueueCount;
+    TitleInfo *latest_app = getLatestTitleInfo(user_app_data->app_info, NULL, NULL);
+    if (latest_app) addNintendoSubmissionPackageToQueue(latest_app);
 
-    TitleInfo *best_app = getBestQueueCandidateFromChain(user_app_data->app_info);
-    if (best_app) addNintendoSubmissionPackageToQueue(best_app);
+    TitleInfo *latest_patch = getLatestTitleInfo(user_app_data->patch_info, NULL, NULL);
+    if (latest_patch) addNintendoSubmissionPackageToQueue(latest_patch);
 
-    TitleInfo *best_patch = getBestQueueCandidateFromChain(user_app_data->patch_info);
-    if (best_patch) addNintendoSubmissionPackageToQueue(best_patch);
+    u64 cur_id = 0;
+    u32 added = 0;
 
-    if (user_app_data->aoc_info)
+    for(TitleInfo *entry = user_app_data->aoc_info; entry; entry = entry->next)
     {
-        typedef struct {
-            u64 id;
-            TitleInfo *best;
-        } BestAocEntry;
+        /* Entries are ordered by TID and version. */
+        if (entry->meta_key.id == cur_id) continue;
 
-        BestAocEntry *best_entries = NULL;
-        u32 best_count = 0;
+        cur_id = entry->meta_key.id;
 
-        for(TitleInfo *cur = user_app_data->aoc_info; cur; cur = cur->next)
-        {
-            bool found = false;
-
-            for(u32 i = 0; i < best_count; i++)
-            {
-                if (best_entries[i].id == cur->meta_key.id)
-                {
-                    found = true;
-                    if (shouldPreferTitleForQueue(cur, best_entries[i].best)) best_entries[i].best = cur;
-                    break;
-                }
-            }
-
-            if (!found)
-            {
-                BestAocEntry *tmp = realloc(best_entries, (best_count + 1) * sizeof(BestAocEntry));
-                if (!tmp) break;
-
-                best_entries = tmp;
-                best_entries[best_count].id = cur->meta_key.id;
-                best_entries[best_count].best = cur;
-                best_count++;
-            }
-        }
-
-        for(u32 i = 0; i < best_count; i++)
-        {
-            if (best_entries[i].best && isQueueEligibleTitle(best_entries[i].best)) addNintendoSubmissionPackageToQueue(best_entries[i].best);
-        }
-
-        if (best_entries) free(best_entries);
+        TitleInfo *latest_aoc = getLatestTitleInfo(entry, NULL, NULL);
+        if (latest_aoc && addNintendoSubmissionPackageToQueue(latest_aoc)) added++;
     }
 
-    if (user_app_data->aoc_patch_info)
+    cur_id = 0;
+
+    for(TitleInfo *entry = user_app_data->aoc_patch_info; entry; entry = entry->next)
     {
-        typedef struct {
-            u64 id;
-            TitleInfo *latest;
-        } LatestPatchEntry;
+        /* Entries are ordered by TID and version. */
+        if (entry->meta_key.id == cur_id) continue;
 
-        LatestPatchEntry *latest_entries = NULL;
-        u32 latest_count = 0;
+        cur_id = entry->meta_key.id;
 
-        for(TitleInfo *cur = user_app_data->aoc_patch_info; cur; cur = cur->next)
-        {
-            bool found = false;
-
-            for(u32 i = 0; i < latest_count; i++)
-            {
-                if (latest_entries[i].id == cur->meta_key.id)
-                {
-                    found = true;
-                    if (shouldPreferTitleForQueue(cur, latest_entries[i].latest)) latest_entries[i].latest = cur;
-                    break;
-                }
-            }
-
-            if (!found)
-            {
-                LatestPatchEntry *tmp = realloc(latest_entries, (latest_count + 1) * sizeof(LatestPatchEntry));
-                if (!tmp) break;
-
-                latest_entries = tmp;
-                latest_entries[latest_count].id = cur->meta_key.id;
-                latest_entries[latest_count].latest = cur;
-                latest_count++;
-            }
-        }
-
-        for(u32 i = 0; i < latest_count; i++)
-        {
-            if (latest_entries[i].latest && isQueueEligibleTitle(latest_entries[i].latest)) addNintendoSubmissionPackageToQueue(latest_entries[i].latest);
-        }
-
-        if (latest_entries) free(latest_entries);
+        TitleInfo *latest_aoc_patch = getLatestTitleInfo(entry, NULL, NULL);
+        if (latest_aoc_patch && addNintendoSubmissionPackageToQueue(latest_aoc_patch)) added++;
     }
 
-    u32 queued_after = g_nspDumpQueueCount;
-    u32 added_count = (queued_after >= queued_before ? (queued_after - queued_before) : 0);
+    consolePrint("bulk queue add finished: %u item(s) added\n", added);
 
-    consolePrint("bulk queue add finished: %u item(s) added\n", added_count);
-
-    return (added_count > 0);
+    return (added > 0);
 }
 
 static bool startNintendoSubmissionPackageQueue(void *userdata)
@@ -2604,6 +2494,7 @@ static bool startNintendoSubmissionPackageQueue(void *userdata)
     for(u32 i = 0; i < g_nspDumpQueueCount;)
     {
         TitleInfo *queue_title_info = g_nspDumpQueue[i];
+        if (!queue_title_info) continue;
 
         consoleClear();
         consolePrint("queued nsp dump %u/%u\n", i + 1, g_nspDumpQueueCount);
@@ -2611,7 +2502,7 @@ static bool startNintendoSubmissionPackageQueue(void *userdata)
         if (saveNintendoSubmissionPackage(queue_title_info))
         {
             success_count++;
-            removeNspQueueEntryByIndex(i);
+            removeNspDumpQueueEntryByIndex(i);
             if (!g_nspDumpQueueCount) break;
         } else {
             fail_count++;
@@ -2622,9 +2513,8 @@ static bool startNintendoSubmissionPackageQueue(void *userdata)
     updateNspQueueViewList();
 
     consolePrint("\nqueue done: %u succeeded, %u failed\n", success_count, fail_count);
-    consolePrint("queue remaining: %u\n", g_nspDumpQueueCount);
 
-    return (success_count > 0 && !fail_count);
+    return (success_count && !fail_count);
 }
 
 static bool clearNintendoSubmissionPackageQueue(void *userdata)
@@ -2650,7 +2540,7 @@ static bool clearNintendoSubmissionPackageQueue(void *userdata)
         consolePrint("nsp queue cleared\n");
     }
 
-    return false;
+    return true;
 }
 
 static bool removeNintendoSubmissionPackageQueueEntry(void *userdata)
@@ -2660,23 +2550,18 @@ static bool removeNintendoSubmissionPackageQueueEntry(void *userdata)
     u32 idx = *((u32*)userdata);
     if (idx >= g_nspDumpQueueCount) return false;
 
-    removeNspQueueEntryByIndex(idx);
+    removeNspDumpQueueEntryByIndex(idx);
 
     updateNspQueueViewList();
 
     consolePrint("queue entry removed\n");
 
-    return false;
+    return true;
 }
 
 static TitleInfo *getLatestTitleInfo(TitleInfo *title_info, u32 *out_idx, u32 *out_count)
 {
-    if (!title_info || !out_idx || !out_count || (title_info->meta_key.type != NcmContentMetaType_Patch && title_info->meta_key.type != NcmContentMetaType_DataPatch))
-    {
-        if (out_idx) *out_idx = 0;
-        if (out_count) *out_count = titleGetCountFromInfoBlock(title_info);
-        return title_info;
-    }
+    if (!titleIsValidInfoBlock(title_info)) return NULL;
 
     u32 idx = 0, count = 1;
     TitleInfo *cur_info = title_info->previous, *out = title_info;
@@ -2685,7 +2570,7 @@ static TitleInfo *getLatestTitleInfo(TitleInfo *title_info, u32 *out_idx, u32 *o
     {
         count++;
 
-        if (cur_info->version.value > out->version.value)
+        if (cur_info->meta_key.id == out->meta_key.id && cur_info->version.value > out->version.value)
         {
             out = cur_info;
             idx = count;
@@ -2702,7 +2587,7 @@ static TitleInfo *getLatestTitleInfo(TitleInfo *title_info, u32 *out_idx, u32 *o
     {
         count++;
 
-        if (cur_info->version.value > out->version.value)
+        if (cur_info->meta_key.id == out->meta_key.id && cur_info->version.value > out->version.value)
         {
             out = cur_info;
             idx = (count - 1);
@@ -2711,8 +2596,8 @@ static TitleInfo *getLatestTitleInfo(TitleInfo *title_info, u32 *out_idx, u32 *o
         cur_info = cur_info->next;
     }
 
-    *out_idx = idx;
-    *out_count = count;
+    if (out_idx) *out_idx = idx;
+    if (out_count) *out_count = count;
 
     return out;
 }

--- a/code_templates/nxdt_rw_poc.c
+++ b/code_templates/nxdt_rw_poc.c
@@ -1304,13 +1304,6 @@ static MenuElement *g_rootMenuElements[] = {
         .userdata = NULL
     },
     &(MenuElement){
-        .str = "nsp queue menu",
-        .child_menu = &g_nspQueueMenu,
-        .task_func = NULL,
-        .element_options = NULL,
-        .userdata = NULL
-    },
-    &(MenuElement){
         .str = "reset settings",
         .child_menu = NULL,
         .task_func = &resetSettings,
@@ -1412,8 +1405,11 @@ int main(int argc, char *argv[])
         if ((cur_menu->id == MenuId_UserTitles || cur_menu->id == MenuId_SystemTitles) && element_count)
         {
             consolePrint("press y to dump csv with title info to the sd card\n");
-            if (cur_menu->id == MenuId_UserTitles) 
-                consolePrint("press zl + zr to add all titles to the nsp dump queue\n");
+            if (cur_menu->id == MenuId_UserTitles)
+            {
+                consolePrint("press zl to add all titles to the nsp dump queue\n");
+                consolePrint("press zr to enter the nsp queue menu\n");
+            }
         }
         consolePrint("use the sticks to scroll faster\n");
         consolePrint("press + to exit\n");
@@ -1578,9 +1574,11 @@ int main(int argc, char *argv[])
 
         if (data_update) continue;
 
-        if ((btn_down & HidNpadButton_A) && selected_element)
+        bool is_nsp_queue_menu_btn_down = ((btn_down & HidNpadButton_ZR) && cur_menu->id == MenuId_UserTitles && element_count);
+
+        if (((btn_down & HidNpadButton_A) && selected_element) || is_nsp_queue_menu_btn_down)
         {
-            Menu *child_menu = selected_element->child_menu;
+            Menu *child_menu = (is_nsp_queue_menu_btn_down ? &g_nspQueueMenu : selected_element->child_menu);
 
             if (child_menu)
             {
@@ -1679,7 +1677,7 @@ int main(int argc, char *argv[])
 
                 if (!error)
                 {
-                    child_menu->parent = cur_menu;
+                    child_menu->parent = (is_nsp_queue_menu_btn_down ? &g_userTitlesMenu : cur_menu);
                     cur_menu = child_menu;
                     element_count = menuGetElementCount(cur_menu);
                 } else {
@@ -1691,11 +1689,6 @@ int main(int argc, char *argv[])
             if (selected_element->task_func)
             {
                 bool show_button_prompt = true;
-                /* For queue management actions, we want to show the button prompt
-                and wait for a button press before going back to the queue view,
-                but we don't want to wait for USB or show the "please wait" message
-                since these actions are usually very fast and waiting for USB or
-                showing the message could be disruptive. */
                 bool is_queue_management_action = (selected_element->task_func == &addTitleToNintendoSubmissionPackageQueueByUserAction || \
                                                    selected_element->task_func == &addAllUserApplicationDataTitlesToNintendoSubmissionPackageQueueByUserAction || \
                                                    selected_element->task_func == &clearNintendoSubmissionPackageQueue || \
@@ -1973,7 +1966,7 @@ int main(int argc, char *argv[])
                 g_ncaMenuElements[i]->task_func = (g_ncaMenuRawMode ? &saveNintendoContentArchive : NULL);
             }
         } else
-        if ((btn_down & HidNpadButton_ZL) && (btn_down & HidNpadButton_ZR) && cur_menu->id == MenuId_UserTitles && element_count)
+        if ((btn_down & HidNpadButton_ZL) && cur_menu->id == MenuId_UserTitles && element_count)
         {
             addAllUserTitlesToNspDumpQueueViewList(element_count);
         } else

--- a/code_templates/nxdt_rw_poc.c
+++ b/code_templates/nxdt_rw_poc.c
@@ -202,14 +202,10 @@ void updateNcaFsSectionsList(NcaUserData *nca_user_data);
 void freeNcaBasePatchList(void);
 void updateNcaBasePatchList(TitleUserApplicationData *user_app_data, TitleInfo *title_info, NcaFsSectionContext *nca_fs_ctx);
 
-void freeNspQueueViewList(void);
-void updateNspQueueViewList(void);
-
-void freeNspDumpQueue(void);
-static bool addNspDumpQueueEntry(TitleInfo *title_info);
-static void removeNspDumpQueueEntryByIndex(u32 idx);
-
-static inline bool isTitleStorageMediumEligibleForNspDumpQueue(const TitleInfo *title_info);
+static void freeNspQueueViewList(void);
+static bool expandNspQueueViewList(TitleInfo *title_info);
+static int nspDumpQueueViewListEntrySortFunction(const void *a, const void *b);
+static void removeNspDumpQueueViewListEntryByTitleInfoPtr(TitleInfo *title_info);
 
 NX_INLINE bool useUsbHost(void);
 
@@ -241,13 +237,13 @@ static bool browseGameCardHfsPartition(void *userdata);
 
 static bool saveConsoleLafwBlob(void *userdata);
 
+static bool saveNintendoSubmissionPackage(void *userdata);
+
 static bool addNintendoSubmissionPackageToQueue(void *userdata);
 static bool addAllAvailableNintendoSubmissionPackagesToQueue(void *userdata);
 static bool startNintendoSubmissionPackageQueue(void *userdata);
 static bool clearNintendoSubmissionPackageQueue(void *userdata);
 static bool removeNintendoSubmissionPackageQueueEntry(void *userdata);
-
-static bool saveNintendoSubmissionPackage(void *userdata);
 
 static bool saveTicket(void *userdata);
 
@@ -383,9 +379,6 @@ static MenuElement g_storageMenuElement = {
     .userdata = NULL
 };
 
-static TitleInfo **g_nspDumpQueue = NULL;
-static u32 g_nspDumpQueueCount = 0;
-static u32 g_nspDumpQueueCapacity = 0;
 static bool g_lastNspDumpUserCancelled = false;
 
 static MenuElementOption g_nspSetDownloadDistributionMenuElementOption = {
@@ -826,9 +819,9 @@ static Menu g_nspMenu = {
     .elements = g_nspMenuElements
 };
 
-static MenuElement **g_nspQueueViewMenuElements = NULL;
+static u32 g_nspQueueViewMenuElementCount = 0;
 
-// Dynamically populated using g_nspQueueViewMenuElements.
+// Dynamically populated via user actions.
 static Menu g_nspQueueViewMenu = {
     .id = MenuId_NspQueueView,
     .parent = NULL,
@@ -1390,7 +1383,7 @@ int main(int argc, char *argv[])
         /* Clamp selection on NSP queue list because it could have been changed. */
         if (cur_menu->id == MenuId_NspQueueView)
         {
-            element_count = menuGetElementCount(cur_menu);
+            element_count = g_nspQueueViewMenuElementCount;
 
             if (cur_menu->selected >= element_count)
             {
@@ -1510,7 +1503,7 @@ int main(int argc, char *argv[])
         if (cur_menu->id == MenuId_NspQueue || cur_menu->id == MenuId_NspQueueView)
         {
             consolePrint("nsp queue status:\n\n");
-            consolePrint("queued items: %u\n", g_nspDumpQueueCount);
+            consolePrint("queued items: %u\n", g_nspQueueViewMenuElementCount);
             if (cur_menu->id == MenuId_NspQueueView) consolePrint("press a on an entry to remove it from the queue\n");
             consolePrint("______________________________\n\n");
         }
@@ -1679,10 +1672,6 @@ int main(int argc, char *argv[])
                         consolePrint("can't dump an invalid nca fs section!\n");
                         error = true;
                     }
-                } else
-                if (child_menu->id == MenuId_NspQueueView)
-                {
-                    updateNspQueueViewList();
                 }
 
                 if (!error)
@@ -1730,7 +1719,7 @@ int main(int argc, char *argv[])
                 } else
                 if (cur_menu->id > MenuId_Root && !is_queue_management_action)
                 {
-                    if (selected_element->task_func != &startNintendoSubmissionPackageQueue || (g_nspDumpQueueCount && g_nspDumpQueue))
+                    if (selected_element->task_func != &startNintendoSubmissionPackageQueue || g_nspQueueViewMenuElementCount)
                     {
                         /* Wait for USB session (if needed). */
                         if (useUsbHost() && !waitForUsb())
@@ -1907,10 +1896,6 @@ int main(int argc, char *argv[])
             if (cur_menu->id == MenuId_NcaFsSectionsSubMenu)
             {
                 freeNcaBasePatchList();
-            } else
-            if (cur_menu->id == MenuId_NspQueueView)
-            {
-                freeNspQueueViewList();
             }
 
             cur_menu = cur_menu->parent;
@@ -1995,14 +1980,12 @@ int main(int argc, char *argv[])
 
     freeNcaList();
 
-    freeNspQueueViewList();
-
-    freeNspDumpQueue();
-
     freeTitleList(&g_systemTitlesMenu);
     freeTitleList(&g_userTitlesMenu);
 
     freeStorageList();
+
+    freeNspQueueViewList();
 
     titleFreeUserApplicationData(&user_app_data);
 
@@ -2261,345 +2244,98 @@ end:
     if (app_metadata) free(app_metadata);
 }
 
-void freeNspQueueViewList(void)
+static void freeNspQueueViewList(void)
 {
-    if (g_nspQueueViewMenuElements)
+    if (g_nspQueueViewMenu.elements)
     {
-        for(u32 i = 0; g_nspQueueViewMenuElements[i]; i++)
+        MenuElement *cur_menu_element = NULL;
+
+        for(u32 i = 0; (cur_menu_element = g_nspQueueViewMenu.elements[i]) != NULL; i++)
         {
-            if (g_nspQueueViewMenuElements[i]->str) free(g_nspQueueViewMenuElements[i]->str);
-            if (g_nspQueueViewMenuElements[i]->userdata) free(g_nspQueueViewMenuElements[i]->userdata);
-            free(g_nspQueueViewMenuElements[i]);
+            if (cur_menu_element->str) free(cur_menu_element->str);
+            if (cur_menu_element->userdata) titleFreeTitleInfo((TitleInfo**)&(cur_menu_element->userdata));
+            free(cur_menu_element);
         }
 
-        free(g_nspQueueViewMenuElements);
-        g_nspQueueViewMenuElements = NULL;
+        free(g_nspQueueViewMenu.elements);
+        g_nspQueueViewMenu.elements = NULL;
     }
 
     g_nspQueueViewMenu.scroll = 0;
     g_nspQueueViewMenu.selected = 0;
-    g_nspQueueViewMenu.elements = NULL;
+
+    g_nspQueueViewMenuElementCount = 0;
 }
 
-void updateNspQueueViewList(void)
-{
-    u32 idx = 0;
-    MenuElement **elements = NULL;
-
-    /* Free all previously allocated data. */
-    freeNspQueueViewList();
-
-    /* Don't proceed any further if there's no actual queue to work with. */
-    if (!g_nspDumpQueueCount || !g_nspDumpQueue) return;
-
-    /* Allocate buffer. */
-    elements = calloc(g_nspDumpQueueCount + 1, sizeof(MenuElement*)); // NULL terminator
-    if (!elements) return;
-
-    /* Generate menu elements. */
-    for(u32 i = 0; i < g_nspDumpQueueCount; i++)
-    {
-        const TitleInfo *title_info = g_nspDumpQueue[i];
-        if (!title_info) continue;
-
-        char *label = NULL;
-        u32 *entry_idx = NULL;
-
-        if (!elements[idx])
-        {
-            elements[idx] = calloc(1, sizeof(MenuElement));
-            if (!elements[idx]) continue;
-        }
-
-        label = titleGenerateFileName(title_info, TitleNamingConvention_Full, TitleFileNameIllegalCharReplaceType_IllegalFsChars);
-        entry_idx = calloc(1, sizeof(u32));
-
-        if (!label || !entry_idx)
-        {
-            if (label) free(label);
-            if (entry_idx) free(entry_idx);
-            continue;
-        }
-
-        *entry_idx = i;
-
-        elements[idx]->str = label;
-        elements[idx]->task_func = &removeNintendoSubmissionPackageQueueEntry;
-        elements[idx]->userdata = entry_idx;
-
-        idx++;
-    }
-
-    g_nspQueueViewMenu.elements = g_nspQueueViewMenuElements = elements;
-}
-
-void freeNspDumpQueue(void)
-{
-    if (g_nspDumpQueue)
-    {
-        for(u32 i = 0; i < g_nspDumpQueueCount; i++) titleFreeTitleInfo(&(g_nspDumpQueue[i]));
-
-        free(g_nspDumpQueue);
-        g_nspDumpQueue = NULL;
-    }
-
-    g_nspDumpQueueCount = 0;
-    g_nspDumpQueueCapacity = 0;
-}
-
-static bool addNspDumpQueueEntry(TitleInfo *title_info)
+static bool expandNspQueueViewList(TitleInfo *title_info)
 {
     if (!title_info) return false;
 
-    if (g_nspDumpQueueCount >= g_nspDumpQueueCapacity)
-    {
-        size_t new_capacity = (g_nspDumpQueueCapacity ? (g_nspDumpQueueCapacity * 2) : 8);
+    MenuElement **elements = NULL, *extra = NULL;
 
-        TitleInfo **new_queue = realloc(g_nspDumpQueue, new_capacity * sizeof(TitleInfo*));
-        if (!new_queue) return false;
+    /* Resize NSP queue view list. */
+    elements = realloc(g_nspQueueViewMenu.elements, (g_nspQueueViewMenuElementCount + 2) * sizeof(MenuElement*)); // New entry + NULL terminator
+    if (!elements) return false;
 
-        g_nspDumpQueue = new_queue;
-        g_nspDumpQueueCapacity = new_capacity;
-    }
+    elements[g_nspQueueViewMenuElementCount] = NULL;
+    elements[g_nspQueueViewMenuElementCount + 1] = NULL;
 
-    g_nspDumpQueue[g_nspDumpQueueCount++] = title_info;
+    g_nspQueueViewMenu.elements = elements;
+    elements = NULL;
+
+    /* Generate new menu element. */
+    extra = calloc(1, sizeof(MenuElement));
+    if (!extra) return false;
+
+    extra->str = titleGenerateFileName(title_info, TitleNamingConvention_Full, TitleFileNameIllegalCharReplaceType_IllegalFsChars);
+    extra->task_func = &removeNintendoSubmissionPackageQueueEntry;
+    extra->userdata = title_info;
+
+    g_nspQueueViewMenu.elements[g_nspQueueViewMenuElementCount++] = extra;
+
+    /* Sort menu element entries. */
+    if (g_nspQueueViewMenuElementCount > 1) qsort(g_nspQueueViewMenu.elements, g_nspQueueViewMenuElementCount, sizeof(MenuElement*), &nspDumpQueueViewListEntrySortFunction);
+
     return true;
 }
 
-static inline bool isTitleStorageMediumEligibleForNspDumpQueue(const TitleInfo *title_info)
+static int nspDumpQueueViewListEntrySortFunction(const void *a, const void *b)
 {
-    return (title_info && (title_info->storage_id == NcmStorageId_GameCard || title_info->storage_id == NcmStorageId_BuiltInUser || title_info->storage_id == NcmStorageId_SdCard));
+    const MenuElement *menu_element_1 = *((const MenuElement**)a);
+    const MenuElement *menu_element_2 = *((const MenuElement**)b);
+
+    return strcasecmp(menu_element_1->str, menu_element_2->str);
 }
 
-static void removeNspDumpQueueEntryByIndex(u32 idx)
+static void removeNspDumpQueueViewListEntryByTitleInfoPtr(TitleInfo *title_info)
 {
-    if (!g_nspDumpQueue || idx >= g_nspDumpQueueCount) return;
+    if (!title_info) return;
 
-    titleFreeTitleInfo(&(g_nspDumpQueue[idx]));
+    u32 idx = UINT32_MAX;
 
-    if (idx < (g_nspDumpQueueCount - 1)) memmove(&(g_nspDumpQueue[idx]), &(g_nspDumpQueue[idx + 1]), (g_nspDumpQueueCount - idx - 1) * sizeof(TitleInfo*));
-
-    g_nspDumpQueueCount--;
-
-    if (!g_nspDumpQueueCount)
+    for(u32 i = 0; i < g_nspQueueViewMenuElementCount; i++)
     {
-        free(g_nspDumpQueue);
-        g_nspDumpQueue = NULL;
-        g_nspDumpQueueCapacity = 0;
-    }
-}
+        MenuElement *cur_menu_element = g_nspQueueViewMenu.elements[i];
+        TitleInfo *entry = (cur_menu_element ? (TitleInfo*)cur_menu_element->userdata : NULL);
 
-static bool addNintendoSubmissionPackageToQueue(void *userdata)
-{
-    if (!userdata) return false;
-
-    TitleInfo *title_info = NULL;
-    bool success = false;
-
-    title_info = titleDuplicateTitleInfo((TitleInfo*)userdata, false);
-    if (!title_info)
-    {
-        consolePrint("failed to duplicate title info for queue\n");
-        goto end;
-    }
-
-    if (!isTitleStorageMediumEligibleForNspDumpQueue(title_info))
-    {
-        consolePrint("queue only supports emmc, sd card and/or gamecard titles\n");
-        goto end;
-    }
-
-    if (title_info->meta_key.type < NcmContentMetaType_Application || title_info->meta_key.type > NcmContentMetaType_DataPatch || title_info->meta_key.type == NcmContentMetaType_Delta)
-    {
-        consolePrint("invalid title type for nsp queue\n");
-        goto end;
-    }
-
-    for(u32 i = 0; i < g_nspDumpQueueCount; i++)
-    {
-        TitleInfo *entry = g_nspDumpQueue[i];
-        if (!entry || entry->meta_key.id != title_info->meta_key.id || entry->meta_key.type != title_info->meta_key.type) continue;
-
-        if (entry->version.value >= title_info->version.value)
+        if (entry == title_info)
         {
-            consolePrint("title %016lX with equal or greater version already queued (v%u >= v%u)\n", entry->meta_key.id, entry->version.value, title_info->version.value);
-            goto end;
-        }
+            if (cur_menu_element->str) free(cur_menu_element->str);
+            titleFreeTitleInfo((TitleInfo**)&(cur_menu_element->userdata));
+            free(cur_menu_element);
 
-        consolePrint("updating queued title %016lX to a newer preferred entry (v%u -> v%u)\n", entry->meta_key.id, entry->version.value, title_info->version.value);
+            g_nspQueueViewMenu.elements[i] = NULL;
+            idx = i;
 
-        titleFreeTitleInfo(&(g_nspDumpQueue[i]));
-        g_nspDumpQueue[i] = title_info;
-        success = true;
-
-        goto end;
-    }
-
-    if (!addNspDumpQueueEntry(title_info))
-    {
-        consolePrint("failed to expand nsp queue\n");
-        goto end;
-    }
-
-    consolePrint("queued %s title %016lX v%u (%u item[s] total)\n", titleGetNcmStorageIdName(title_info->storage_id), title_info->meta_key.id, title_info->meta_key.version, g_nspDumpQueueCount);
-    success = true;
-
-end:
-    if (!success) titleFreeTitleInfo(&title_info);
-
-    return success;
-}
-
-static bool addAllAvailableNintendoSubmissionPackagesToQueue(void *userdata)
-{
-    TitleUserApplicationData *user_app_data = (TitleUserApplicationData*)userdata;
-    if (!user_app_data)
-    {
-        consolePrint("invalid user application data\n");
-        return false;
-    }
-
-    consolePrint("warning: this will queue all available nsp dump targets for the selected user\n");
-    consolePrint("title entry, including base app, latest update, all dlc and dlc updates\n");
-    consolePrint("press a to proceed, or b to cancel\n\n");
-
-    u64 btn_down = utilsWaitForButtonPress(HidNpadButton_A | HidNpadButton_B);
-    if (btn_down & HidNpadButton_B)
-    {
-        consolePrint("bulk queue add cancelled\n");
-        return false;
-    }
-
-    TitleInfo *latest_app = getLatestTitleInfo(user_app_data->app_info, NULL, NULL);
-    if (latest_app) addNintendoSubmissionPackageToQueue(latest_app);
-
-    TitleInfo *latest_patch = getLatestTitleInfo(user_app_data->patch_info, NULL, NULL);
-    if (latest_patch) addNintendoSubmissionPackageToQueue(latest_patch);
-
-    u64 cur_id = 0;
-    u32 added = 0;
-
-    for(TitleInfo *entry = user_app_data->aoc_info; entry; entry = entry->next)
-    {
-        /* Entries are ordered by TID and version. */
-        if (entry->meta_key.id == cur_id) continue;
-
-        cur_id = entry->meta_key.id;
-
-        TitleInfo *latest_aoc = getLatestTitleInfo(entry, NULL, NULL);
-        if (latest_aoc && addNintendoSubmissionPackageToQueue(latest_aoc)) added++;
-    }
-
-    cur_id = 0;
-
-    for(TitleInfo *entry = user_app_data->aoc_patch_info; entry; entry = entry->next)
-    {
-        /* Entries are ordered by TID and version. */
-        if (entry->meta_key.id == cur_id) continue;
-
-        cur_id = entry->meta_key.id;
-
-        TitleInfo *latest_aoc_patch = getLatestTitleInfo(entry, NULL, NULL);
-        if (latest_aoc_patch && addNintendoSubmissionPackageToQueue(latest_aoc_patch)) added++;
-    }
-
-    consolePrint("bulk queue add finished: %u item(s) added\n", added);
-
-    return (added > 0);
-}
-
-static bool startNintendoSubmissionPackageQueue(void *userdata)
-{
-    NX_IGNORE_ARG(userdata);
-
-    if (!g_nspDumpQueueCount || !g_nspDumpQueue)
-    {
-        consolePrint("nsp queue is empty\n");
-        return false;
-    }
-
-    u32 success_count = 0, fail_count = 0;
-    bool queue_cancelled = false;
-
-    for(u32 i = 0; i < g_nspDumpQueueCount;)
-    {
-        TitleInfo *queue_title_info = g_nspDumpQueue[i];
-        if (!queue_title_info) continue;
-
-        consoleClear();
-        consolePrint("queued nsp dump %u/%u\n", i + 1, g_nspDumpQueueCount);
-
-        if (saveNintendoSubmissionPackage(queue_title_info))
-        {
-            success_count++;
-            removeNspDumpQueueEntryByIndex(i);
-            if (!g_nspDumpQueueCount) break;
-        } else {
-            if (g_lastNspDumpUserCancelled)
-            {
-                queue_cancelled = true;
-                break;
-            }
-
-            fail_count++;
-            i++;
+            break;
         }
     }
 
-    updateNspQueueViewList();
+    if (idx == UINT32_MAX) return;
 
-    if (queue_cancelled)
-    {
-        consolePrint("\nqueue cancelled by user\n");
-        consolePrint("completed: %u | failed: %u | remaining: %u\n", success_count, fail_count, g_nspDumpQueueCount);
-        return false;
-    }
+    if (idx < (g_nspQueueViewMenuElementCount - 1)) memmove(&(g_nspQueueViewMenu.elements[idx]), &(g_nspQueueViewMenu.elements[idx + 1]), (g_nspQueueViewMenuElementCount - idx) * sizeof(MenuElement*)); // Move NULL terminator too
 
-    consolePrint("\nqueue done: %u succeeded, %u failed\n", success_count, fail_count);
-
-    return (success_count && !fail_count);
-}
-
-static bool clearNintendoSubmissionPackageQueue(void *userdata)
-{
-    NX_IGNORE_ARG(userdata);
-
-    if (!g_nspDumpQueueCount || !g_nspDumpQueue)
-    {
-        consolePrint("nsp queue is already empty\n");
-        return false;
-    }
-
-    consolePrint("are you sure you want to clear the nsp queue?\n");
-    consolePrint("press a to proceed, or b to cancel\n\n");
-
-    u64 btn_down = utilsWaitForButtonPress(HidNpadButton_A | HidNpadButton_B);
-    if (btn_down & HidNpadButton_A)
-    {
-        freeNspDumpQueue();
-
-        freeNspQueueViewList();
-
-        consolePrint("nsp queue cleared\n");
-    }
-
-    return true;
-}
-
-static bool removeNintendoSubmissionPackageQueueEntry(void *userdata)
-{
-    if (!userdata || !g_nspDumpQueueCount || !g_nspDumpQueue) return false;
-
-    u32 idx = *((u32*)userdata);
-    if (idx >= g_nspDumpQueueCount) return false;
-
-    removeNspDumpQueueEntryByIndex(idx);
-
-    updateNspQueueViewList();
-
-    consolePrint("queue entry removed\n");
-
-    return true;
+    if (!--g_nspQueueViewMenuElementCount) freeNspQueueViewList();
 }
 
 static TitleInfo *getLatestTitleInfo(TitleInfo *title_info, u32 *out_idx, u32 *out_count)
@@ -4186,6 +3922,225 @@ static bool saveNintendoSubmissionPackage(void *userdata)
     consoleRefresh();
 
     return success;
+}
+
+static bool addNintendoSubmissionPackageToQueue(void *userdata)
+{
+    if (!userdata) return false;
+
+    TitleInfo *title_info = NULL;
+    bool success = false;
+
+    title_info = titleDuplicateTitleInfo((TitleInfo*)userdata, false);
+    if (!title_info)
+    {
+        consolePrint("failed to duplicate title info for queue\n");
+        goto end;
+    }
+
+    if (title_info->storage_id != NcmStorageId_GameCard && title_info->storage_id != NcmStorageId_BuiltInUser && title_info->storage_id != NcmStorageId_SdCard)
+    {
+        consolePrint("queue only supports emmc, sd card and/or gamecard titles\n");
+        goto end;
+    }
+
+    if (title_info->meta_key.type < NcmContentMetaType_Application || title_info->meta_key.type > NcmContentMetaType_DataPatch || title_info->meta_key.type == NcmContentMetaType_Delta)
+    {
+        consolePrint("invalid title type for nsp queue\n");
+        goto end;
+    }
+
+    for(u32 i = 0; i < g_nspQueueViewMenuElementCount; i++)
+    {
+        MenuElement *cur_menu_element = g_nspQueueViewMenu.elements[i];
+        TitleInfo *entry = (cur_menu_element ? (TitleInfo*)cur_menu_element->userdata : NULL);
+        if (!entry || entry->meta_key.id != title_info->meta_key.id || entry->meta_key.type != title_info->meta_key.type) continue;
+
+        if (entry->version.value >= title_info->version.value)
+        {
+            consolePrint("title %016lX with equal or greater version already queued (v%u >= v%u)\n", entry->meta_key.id, entry->version.value, title_info->version.value);
+            goto end;
+        }
+
+        consolePrint("updating queued title %016lX to a newer preferred entry (v%u -> v%u)\n", entry->meta_key.id, entry->version.value, title_info->version.value);
+
+        if (cur_menu_element->str) free(cur_menu_element->str);
+        titleFreeTitleInfo((TitleInfo**)&(cur_menu_element->userdata));
+
+        cur_menu_element->str = titleGenerateFileName(title_info, TitleNamingConvention_Full, TitleFileNameIllegalCharReplaceType_IllegalFsChars);
+        cur_menu_element->userdata = title_info;
+
+        success = true;
+
+        goto end;
+    }
+
+    if (!expandNspQueueViewList(title_info))
+    {
+        consolePrint("failed to expand nsp queue\n");
+        goto end;
+    }
+
+    consolePrint("queued %s title %016lX v%u (%u item[s] total)\n", titleGetNcmStorageIdName(title_info->storage_id), title_info->meta_key.id, title_info->meta_key.version, g_nspQueueViewMenuElementCount);
+    success = true;
+
+end:
+    if (!success) titleFreeTitleInfo(&title_info);
+
+    return success;
+}
+
+static bool addAllAvailableNintendoSubmissionPackagesToQueue(void *userdata)
+{
+    TitleUserApplicationData *user_app_data = (TitleUserApplicationData*)userdata;
+    if (!user_app_data)
+    {
+        consolePrint("invalid user application data\n");
+        return false;
+    }
+
+    consolePrint("warning: this will queue all available nsp dump targets for the selected user\n");
+    consolePrint("title entry, including base app, latest update, all dlc and dlc updates\n");
+    consolePrint("press a to proceed, or b to cancel\n\n");
+
+    u64 btn_down = utilsWaitForButtonPress(HidNpadButton_A | HidNpadButton_B);
+    if (btn_down & HidNpadButton_B)
+    {
+        consolePrint("bulk queue add cancelled\n");
+        return false;
+    }
+
+    u64 cur_id = 0;
+    u32 added = 0;
+
+    TitleInfo *latest_app = getLatestTitleInfo(user_app_data->app_info, NULL, NULL);
+    if (latest_app && addNintendoSubmissionPackageToQueue(latest_app)) added++;
+
+    TitleInfo *latest_patch = getLatestTitleInfo(user_app_data->patch_info, NULL, NULL);
+    if (latest_patch && addNintendoSubmissionPackageToQueue(latest_patch)) added++;
+
+    for(TitleInfo *entry = user_app_data->aoc_info; entry; entry = entry->next)
+    {
+        /* Entries are ordered by TID and version. */
+        if (entry->meta_key.id == cur_id) continue;
+
+        cur_id = entry->meta_key.id;
+
+        TitleInfo *latest_aoc = getLatestTitleInfo(entry, NULL, NULL);
+        if (latest_aoc && addNintendoSubmissionPackageToQueue(latest_aoc)) added++;
+    }
+
+    cur_id = 0;
+
+    for(TitleInfo *entry = user_app_data->aoc_patch_info; entry; entry = entry->next)
+    {
+        /* Entries are ordered by TID and version. */
+        if (entry->meta_key.id == cur_id) continue;
+
+        cur_id = entry->meta_key.id;
+
+        TitleInfo *latest_aoc_patch = getLatestTitleInfo(entry, NULL, NULL);
+        if (latest_aoc_patch && addNintendoSubmissionPackageToQueue(latest_aoc_patch)) added++;
+    }
+
+    consolePrint("bulk queue add finished: %u item(s) added\n", added);
+
+    return (added > 0);
+}
+
+static bool startNintendoSubmissionPackageQueue(void *userdata)
+{
+    NX_IGNORE_ARG(userdata);
+
+    const u32 queue_count = g_nspQueueViewMenuElementCount;
+    u32 success_count = 0, fail_count = 0, pending = queue_count;
+    bool queue_cancelled = false;
+
+    if (!queue_count)
+    {
+        consolePrint("nsp queue is empty\n");
+        return false;
+    }
+
+    for(u32 i = 0, j = 0; i < queue_count; i++)
+    {
+        MenuElement *cur_menu_element = g_nspQueueViewMenu.elements[j];
+        TitleInfo *entry = (cur_menu_element ? (TitleInfo*)cur_menu_element->userdata : NULL);
+        if (!entry)
+        {
+            j++;
+            fail_count++;
+            continue;
+        }
+
+        consoleClear();
+        consolePrint("queued nsp dump %u/%u\n", i + 1, queue_count);
+
+        if (saveNintendoSubmissionPackage(entry))
+        {
+            removeNspDumpQueueViewListEntryByTitleInfoPtr(entry);
+
+            success_count++;
+            pending--;
+
+            if (!pending) break;
+        } else {
+            if (g_lastNspDumpUserCancelled)
+            {
+                queue_cancelled = true;
+                break;
+            }
+
+            j++;
+            fail_count++;
+        }
+    }
+
+    if (queue_cancelled)
+    {
+        consolePrint("\nqueue cancelled by user\n");
+        consolePrint("completed: %u | failed: %u | pending: %u\n", success_count, fail_count, pending);
+        return false;
+    }
+
+    consolePrint("\nqueue done: %u succeeded, %u failed\n", success_count, fail_count);
+
+    return (success_count && !fail_count);
+}
+
+static bool clearNintendoSubmissionPackageQueue(void *userdata)
+{
+    NX_IGNORE_ARG(userdata);
+
+    if (!g_nspQueueViewMenuElementCount)
+    {
+        consolePrint("nsp queue is already empty\n");
+        return false;
+    }
+
+    consolePrint("are you sure you want to clear the nsp queue?\n");
+    consolePrint("press a to proceed, or b to cancel\n\n");
+
+    u64 btn_down = utilsWaitForButtonPress(HidNpadButton_A | HidNpadButton_B);
+    if (btn_down & HidNpadButton_A)
+    {
+        freeNspQueueViewList();
+        consolePrint("nsp queue cleared\n");
+    }
+
+    return true;
+}
+
+static bool removeNintendoSubmissionPackageQueueEntry(void *userdata)
+{
+    TitleInfo *title_info = (TitleInfo*)userdata;
+    if (!title_info) return false;
+
+    removeNspDumpQueueViewListEntryByTitleInfoPtr(title_info);
+
+    consolePrint("queue entry removed\n");
+
+    return true;
 }
 
 static bool saveTicket(void *userdata)

--- a/code_templates/nxdt_rw_poc.c
+++ b/code_templates/nxdt_rw_poc.c
@@ -1693,10 +1693,6 @@ int main(int argc, char *argv[])
                                                    selected_element->task_func == &addAllAvailableNintendoSubmissionPackagesToQueue ||
                                                    selected_element->task_func == &clearNintendoSubmissionPackageQueue ||
                                                    selected_element->task_func == &removeNintendoSubmissionPackageQueueEntry);
-                bool is_queue_management_context = ((cur_menu->id == MenuId_Nsp && cur_menu->selected == 1) ||
-                                                   (cur_menu->id == MenuId_NspQueue && cur_menu->selected == 1) ||
-                                                   (cur_menu->id == MenuId_NspQueueView));
-                bool skip_dump_path = (is_queue_management_action || is_queue_management_context);
 
                 consoleClear();
 
@@ -1717,7 +1713,7 @@ int main(int argc, char *argv[])
                     /* Update free space. */
                     if (!useUsbHost()) updateStorageList();
                 } else
-                if (skip_dump_path)
+                if (is_queue_management_action)
                 {
                     /* Ignore result for queue-only management actions. */
                     selected_element->task_func(selected_element->userdata);
@@ -2418,7 +2414,7 @@ static bool addNintendoSubmissionPackageToQueue(void *userdata)
         return false;
     }
 
-    if (title_info->meta_key.type < NcmContentMetaType_Application || title_info->meta_key.type > NcmContentMetaType_DataPatch)
+    if (title_info->meta_key.type < NcmContentMetaType_Application || title_info->meta_key.type > NcmContentMetaType_DataPatch || title_info->meta_key.type == NcmContentMetaType_Delta)
     {
         consolePrint("invalid title type for nsp queue\n");
         return false;

--- a/code_templates/nxdt_rw_poc.c
+++ b/code_templates/nxdt_rw_poc.c
@@ -170,13 +170,6 @@ typedef struct {
     SystemUpdateDumpContext *sys_upd_dump_ctx;
 } SystemUpdateThreadData;
 
-typedef struct {
-    u64 title_id;
-    u8 meta_type;
-    bool is_system;
-    char name[0x201];
-} NspQueueEntry;
-
 /* Function prototypes. */
 
 static void utilsScanPads(void);
@@ -211,6 +204,12 @@ void updateNcaBasePatchList(TitleUserApplicationData *user_app_data, TitleInfo *
 
 void freeNspQueueViewList(void);
 void updateNspQueueViewList(void);
+void freeNspDumpQueue(void);
+static bool addNspQueueEntry(TitleInfo *title_info);
+static void removeNspQueueEntryByIndex(u32 idx);
+static bool isQueueEligibleTitle(const TitleInfo *title_info);
+static bool shouldPreferTitleForQueue(const TitleInfo *candidate, const TitleInfo *current);
+static TitleInfo *getBestQueueCandidateFromChain(TitleInfo *title_info);
 
 NX_INLINE bool useUsbHost(void);
 
@@ -384,8 +383,9 @@ static MenuElement g_storageMenuElement = {
     .userdata = NULL
 };
 
-static NspQueueEntry *g_nspDumpQueue = NULL;
+static TitleInfo **g_nspDumpQueue = NULL;
 static u32 g_nspDumpQueueCount = 0;
+static u32 g_nspDumpQueueCapacity = 0;
 
 static MenuElementOption g_nspSetDownloadDistributionMenuElementOption = {
     .selected = 0,
@@ -1059,7 +1059,7 @@ static u32 g_metaTypePatch = NcmContentMetaType_Patch;
 static u32 g_metaTypeAOC = NcmContentMetaType_AddOnContent;
 static u32 g_metaTypeAOCPatch = NcmContentMetaType_DataPatch;
 
-static MenuElement *g_titleTypesMenuElements[] = {
+static MenuElement *g_nspTitleTypesMenuElements[] = {
     &(MenuElement){
         .str = "dump base application",
         .child_menu = NULL, // Dynamically set
@@ -1098,6 +1098,38 @@ static MenuElement *g_titleTypesMenuElements[] = {
     NULL
 };
 
+static MenuElement *g_titleTypesMenuElements[] = {
+    &(MenuElement){
+        .str = "dump base application",
+        .child_menu = NULL, // Dynamically set
+        .task_func = NULL,
+        .element_options = NULL,
+        .userdata = &g_metaTypeApplication
+    },
+    &(MenuElement){
+        .str = "dump update",
+        .child_menu = NULL, // Dynamically set
+        .task_func = NULL,
+        .element_options = NULL,
+        .userdata = &g_metaTypePatch
+    },
+    &(MenuElement){
+        .str = "dump dlc",
+        .child_menu = NULL, // Dynamically set
+        .task_func = NULL,
+        .element_options = NULL,
+        .userdata = &g_metaTypeAOC
+    },
+    &(MenuElement){
+        .str = "dump dlc update",
+        .child_menu = NULL, // Dynamically set
+        .task_func = NULL,
+        .element_options = NULL,
+        .userdata = &g_metaTypeAOCPatch
+    },
+    NULL
+};
+
 static MenuElement *g_userTitlesSubMenuElements[] = {
     &(MenuElement){
         .str = "nsp dump options",
@@ -1106,7 +1138,7 @@ static MenuElement *g_userTitlesSubMenuElements[] = {
             .parent = NULL,
             .selected = 0,
             .scroll = 0,
-            .elements = g_titleTypesMenuElements
+            .elements = g_nspTitleTypesMenuElements
         },
         .task_func = NULL,
         .element_options = NULL,
@@ -1372,12 +1404,15 @@ int main(int argc, char *argv[])
             /* Set title types child menu pointer if we're currently at the user titles submenu. */
             u32 child_id = selected_element->child_menu->id;
 
-            g_titleTypesMenuElements[0]->child_menu = g_titleTypesMenuElements[1]->child_menu = \
-            g_titleTypesMenuElements[2]->child_menu = g_titleTypesMenuElements[3]->child_menu = (child_id == MenuId_NspTitleTypes ? &g_nspMenu : \
-                                                                                                (child_id == MenuId_TicketTitleTypes ? &g_ticketMenu : \
-                                                                                                (child_id == MenuId_NcaTitleTypes ? &g_ncaMenu : NULL)));
+            Menu *target_menu = (child_id == MenuId_NspTitleTypes ? &g_nspMenu : (child_id == MenuId_TicketTitleTypes ? &g_ticketMenu : (child_id == MenuId_NcaTitleTypes ? &g_ncaMenu : NULL)));
 
-            g_titleTypesMenuElements[4]->userdata = (child_id == MenuId_NspTitleTypes ? &user_app_data : NULL);
+            g_nspTitleTypesMenuElements[0]->child_menu = g_nspTitleTypesMenuElements[1]->child_menu = \
+            g_nspTitleTypesMenuElements[2]->child_menu = g_nspTitleTypesMenuElements[3]->child_menu = target_menu;
+
+            g_titleTypesMenuElements[0]->child_menu = g_titleTypesMenuElements[1]->child_menu = \
+            g_titleTypesMenuElements[2]->child_menu = g_titleTypesMenuElements[3]->child_menu = target_menu;
+
+            g_nspTitleTypesMenuElements[4]->userdata = (child_id == MenuId_NspTitleTypes ? &user_app_data : NULL);
         }
 
         consoleClear();
@@ -1807,9 +1842,12 @@ int main(int argc, char *argv[])
             if (cur_menu->id == MenuId_UserTitlesSubMenu)
             {
                 titleFreeUserApplicationData(&user_app_data);
+                g_nspTitleTypesMenuElements[0]->child_menu = g_nspTitleTypesMenuElements[1]->child_menu = \
+                g_nspTitleTypesMenuElements[2]->child_menu = g_nspTitleTypesMenuElements[3]->child_menu = NULL;
+                g_nspTitleTypesMenuElements[4]->userdata = NULL;
+
                 g_titleTypesMenuElements[0]->child_menu = g_titleTypesMenuElements[1]->child_menu = \
                 g_titleTypesMenuElements[2]->child_menu = g_titleTypesMenuElements[3]->child_menu = NULL;
-                g_titleTypesMenuElements[4]->userdata = NULL;
             } else
             if (cur_menu->id == MenuId_NspTitleTypes || cur_menu->id == MenuId_TicketTitleTypes || cur_menu->id == MenuId_NcaTitleTypes)
             {
@@ -1932,7 +1970,7 @@ int main(int argc, char *argv[])
 
     freeNspQueueViewList();
 
-    if (g_nspDumpQueue) free(g_nspDumpQueue);
+    freeNspDumpQueue();
 
     freeTitleList(&g_systemTitlesMenu);
     freeTitleList(&g_userTitlesMenu);
@@ -2228,8 +2266,8 @@ void updateNspQueueViewList(void)
 
     for(u32 i = 0; i < g_nspDumpQueueCount; i++)
     {
-        const NspQueueEntry *entry = &(g_nspDumpQueue[i]);
-        const char *type_str = titleGetNcmContentMetaTypeName(entry->meta_type);
+        const TitleInfo *title_info = g_nspDumpQueue[i];
+        const char *type_str = (title_info ? titleGetNcmContentMetaTypeName(title_info->meta_key.type) : NULL);
         char *label = NULL;
         u32 *entry_idx = NULL;
 
@@ -2250,7 +2288,10 @@ void updateNspQueueViewList(void)
 
         *entry_idx = i;
 
-        snprintf(label, 0x400, "remove: %s [%016lX] (%s)", entry->name, entry->title_id, (type_str ? type_str : "unknown"));
+        snprintf(label, 0x400, "remove: %s [%016lX] (%s)", \
+             (title_info && title_info->app_metadata && title_info->app_metadata->name[0] ? title_info->app_metadata->name : "unknown"), \
+             (title_info ? title_info->meta_key.id : 0), \
+             (type_str ? type_str : "unknown"));
 
         g_nspQueueViewMenuElements[idx]->str = label;
         g_nspQueueViewMenuElements[idx]->child_menu = NULL;
@@ -2270,11 +2311,112 @@ void updateNspQueueViewList(void)
     g_nspQueueViewMenu.elements = g_nspQueueViewMenuElements;
 }
 
+void freeNspDumpQueue(void)
+{
+    if (g_nspDumpQueue)
+    {
+        for(u32 i = 0; i < g_nspDumpQueueCount; i++)
+        {
+            if (g_nspDumpQueue[i]) titleFreeTitleInfo(&(g_nspDumpQueue[i]));
+        }
+
+        free(g_nspDumpQueue);
+        g_nspDumpQueue = NULL;
+    }
+
+    g_nspDumpQueueCount = 0;
+    g_nspDumpQueueCapacity = 0;
+}
+
+static bool addNspQueueEntry(TitleInfo *title_info)
+{
+    if (!title_info) return false;
+
+    if (g_nspDumpQueueCount >= g_nspDumpQueueCapacity)
+    {
+        u32 new_capacity = (g_nspDumpQueueCapacity ? (g_nspDumpQueueCapacity * 2) : 8);
+        TitleInfo **new_queue = realloc(g_nspDumpQueue, new_capacity * sizeof(TitleInfo*));
+        if (!new_queue) return false;
+
+        g_nspDumpQueue = new_queue;
+        g_nspDumpQueueCapacity = new_capacity;
+    }
+
+    g_nspDumpQueue[g_nspDumpQueueCount++] = title_info;
+    return true;
+}
+
+static bool isQueueEligibleTitle(const TitleInfo *title_info)
+{
+    if (!title_info) return false;
+
+    return (title_info->storage_id == NcmStorageId_BuiltInUser || title_info->storage_id == NcmStorageId_SdCard);
+}
+
+static bool shouldPreferTitleForQueue(const TitleInfo *candidate, const TitleInfo *current)
+{
+    if (!candidate) return false;
+    if (!current) return true;
+
+    bool candidate_eligible = isQueueEligibleTitle(candidate);
+    bool current_eligible = isQueueEligibleTitle(current);
+
+    if (candidate_eligible && !current_eligible) return true;
+    if (!candidate_eligible) return false;
+
+    if (candidate->version.value > current->version.value) return true;
+    if (candidate->version.value < current->version.value) return false;
+
+    return (candidate->storage_id == NcmStorageId_SdCard && current->storage_id == NcmStorageId_BuiltInUser);
+}
+
+static TitleInfo *getBestQueueCandidateFromChain(TitleInfo *title_info)
+{
+    if (!title_info) return NULL;
+
+    TitleInfo *best = NULL;
+
+    TitleInfo *cur = title_info;
+    while(cur->previous) cur = cur->previous;
+
+    for(; cur; cur = cur->next)
+    {
+        if (shouldPreferTitleForQueue(cur, best)) best = cur;
+    }
+
+    return best;
+}
+
+static void removeNspQueueEntryByIndex(u32 idx)
+{
+    if (!g_nspDumpQueue || idx >= g_nspDumpQueueCount) return;
+
+    if (g_nspDumpQueue[idx]) titleFreeTitleInfo(&(g_nspDumpQueue[idx]));
+
+    if (idx < (g_nspDumpQueueCount - 1)) memmove(&(g_nspDumpQueue[idx]), &(g_nspDumpQueue[idx + 1]), (g_nspDumpQueueCount - idx - 1) * sizeof(TitleInfo*));
+
+    g_nspDumpQueueCount--;
+
+    if (!g_nspDumpQueueCount)
+    {
+        free(g_nspDumpQueue);
+        g_nspDumpQueue = NULL;
+        g_nspDumpQueueCapacity = 0;
+    }
+}
+
 static bool addNintendoSubmissionPackageToQueue(void *userdata)
 {
     if (!userdata) return false;
 
     TitleInfo *title_info = (TitleInfo*)userdata;
+    TitleInfo *queue_title_info = NULL;
+
+    if (!isQueueEligibleTitle(title_info))
+    {
+        consolePrint("queue only supports user-installed titles (nand/sd)\n");
+        return false;
+    }
 
     if (title_info->meta_key.type < NcmContentMetaType_Application || title_info->meta_key.type > NcmContentMetaType_DataPatch)
     {
@@ -2284,36 +2426,45 @@ static bool addNintendoSubmissionPackageToQueue(void *userdata)
 
     for(u32 i = 0; i < g_nspDumpQueueCount; i++)
     {
-        NspQueueEntry *entry = &(g_nspDumpQueue[i]);
-        if (entry->title_id == title_info->meta_key.id && entry->meta_type == title_info->meta_key.type)
+        TitleInfo *entry = g_nspDumpQueue[i];
+        if (entry && entry->meta_key.id == title_info->meta_key.id && entry->meta_key.type == title_info->meta_key.type)
         {
-            consolePrint("title already queued\n");
-            return false;
+            if (!shouldPreferTitleForQueue(title_info, entry))
+            {
+                consolePrint("title already queued\n");
+                return false;
+            }
+
+            queue_title_info = titleDuplicateTitleInfoEntry(title_info);
+            if (!queue_title_info)
+            {
+                consolePrint("failed to duplicate title info for queue\n");
+                return false;
+            }
+
+            titleFreeTitleInfo(&(g_nspDumpQueue[i]));
+            g_nspDumpQueue[i] = queue_title_info;
+
+            consolePrint("updated queued title %016lX to a newer preferred entry\n", title_info->meta_key.id);
+            return true;
         }
     }
 
-    NspQueueEntry *new_queue = realloc(g_nspDumpQueue, (g_nspDumpQueueCount + 1) * sizeof(NspQueueEntry));
-    if (!new_queue)
+    queue_title_info = titleDuplicateTitleInfoEntry(title_info);
+    if (!queue_title_info)
     {
+        consolePrint("failed to duplicate title info for queue\n");
+        return false;
+    }
+
+    if (!addNspQueueEntry(queue_title_info))
+    {
+        titleFreeTitleInfo(&queue_title_info);
         consolePrint("failed to expand nsp queue\n");
         return false;
     }
 
-    g_nspDumpQueue = new_queue;
-
-    NspQueueEntry *new_entry = &(g_nspDumpQueue[g_nspDumpQueueCount]);
-    memset(new_entry, 0, sizeof(NspQueueEntry));
-
-    new_entry->title_id = title_info->meta_key.id;
-    new_entry->meta_type = title_info->meta_key.type;
-    new_entry->is_system = (title_info->storage_id == NcmStorageId_BuiltInSystem);
-
-    const char *name = (title_info->app_metadata && title_info->app_metadata->name[0] ? title_info->app_metadata->name : "unknown");
-    snprintf(new_entry->name, sizeof(new_entry->name), "%s", name);
-
-    g_nspDumpQueueCount++;
-
-    consolePrint("queued title %016lX (%u item(s) total)\n", new_entry->title_id, g_nspDumpQueueCount);
+    consolePrint("queued title %016lX (%u item(s) total)\n", title_info->meta_key.id, g_nspDumpQueueCount);
 
     return true;
 }
@@ -2340,18 +2491,54 @@ static bool addAllAvailableNintendoSubmissionPackagesToQueue(void *userdata)
 
     u32 queued_before = g_nspDumpQueueCount;
 
-    if (user_app_data->app_info) addNintendoSubmissionPackageToQueue(user_app_data->app_info);
+    TitleInfo *best_app = getBestQueueCandidateFromChain(user_app_data->app_info);
+    if (best_app) addNintendoSubmissionPackageToQueue(best_app);
 
-    if (user_app_data->patch_info)
-    {
-        u32 patch_idx = 0, patch_count = 0;
-        TitleInfo *latest_patch = getLatestTitleInfo(user_app_data->patch_info, &patch_idx, &patch_count);
-        if (latest_patch) addNintendoSubmissionPackageToQueue(latest_patch);
-    }
+    TitleInfo *best_patch = getBestQueueCandidateFromChain(user_app_data->patch_info);
+    if (best_patch) addNintendoSubmissionPackageToQueue(best_patch);
 
-    for(TitleInfo *cur = user_app_data->aoc_info; cur; cur = cur->next)
+    if (user_app_data->aoc_info)
     {
-        addNintendoSubmissionPackageToQueue(cur);
+        typedef struct {
+            u64 id;
+            TitleInfo *best;
+        } BestAocEntry;
+
+        BestAocEntry *best_entries = NULL;
+        u32 best_count = 0;
+
+        for(TitleInfo *cur = user_app_data->aoc_info; cur; cur = cur->next)
+        {
+            bool found = false;
+
+            for(u32 i = 0; i < best_count; i++)
+            {
+                if (best_entries[i].id == cur->meta_key.id)
+                {
+                    found = true;
+                    if (shouldPreferTitleForQueue(cur, best_entries[i].best)) best_entries[i].best = cur;
+                    break;
+                }
+            }
+
+            if (!found)
+            {
+                BestAocEntry *tmp = realloc(best_entries, (best_count + 1) * sizeof(BestAocEntry));
+                if (!tmp) break;
+
+                best_entries = tmp;
+                best_entries[best_count].id = cur->meta_key.id;
+                best_entries[best_count].best = cur;
+                best_count++;
+            }
+        }
+
+        for(u32 i = 0; i < best_count; i++)
+        {
+            if (best_entries[i].best && isQueueEligibleTitle(best_entries[i].best)) addNintendoSubmissionPackageToQueue(best_entries[i].best);
+        }
+
+        if (best_entries) free(best_entries);
     }
 
     if (user_app_data->aoc_patch_info)
@@ -2373,7 +2560,7 @@ static bool addAllAvailableNintendoSubmissionPackagesToQueue(void *userdata)
                 if (latest_entries[i].id == cur->meta_key.id)
                 {
                     found = true;
-                    if (cur->version.value > latest_entries[i].latest->version.value) latest_entries[i].latest = cur;
+                    if (shouldPreferTitleForQueue(cur, latest_entries[i].latest)) latest_entries[i].latest = cur;
                     break;
                 }
             }
@@ -2390,7 +2577,10 @@ static bool addAllAvailableNintendoSubmissionPackagesToQueue(void *userdata)
             }
         }
 
-        for(u32 i = 0; i < latest_count; i++) addNintendoSubmissionPackageToQueue(latest_entries[i].latest);
+        for(u32 i = 0; i < latest_count; i++)
+        {
+            if (latest_entries[i].latest && isQueueEligibleTitle(latest_entries[i].latest)) addNintendoSubmissionPackageToQueue(latest_entries[i].latest);
+        }
 
         if (latest_entries) free(latest_entries);
     }
@@ -2417,77 +2607,20 @@ static bool startNintendoSubmissionPackageQueue(void *userdata)
 
     for(u32 i = 0; i < g_nspDumpQueueCount;)
     {
-        NspQueueEntry *entry = &(g_nspDumpQueue[i]);
-        u32 title_idx = 0, title_count = 0;
-
-        TitleInfo *title_info_root = titleGetTitleInfoEntryFromStorageByTitleId(entry->is_system ? NcmStorageId_BuiltInSystem : NcmStorageId_Any, entry->title_id);
-        TitleInfo *title_info = title_info_root;
-
-        if (!title_info_root)
-        {
-            consolePrint("[%u/%u] failed to resolve %016lX\n", i + 1, g_nspDumpQueueCount, entry->title_id);
-            fail_count++;
-            continue;
-        }
-
-        title_info = getLatestTitleInfo(title_info, &title_idx, &title_count);
-
-        if (title_info->meta_key.type != entry->meta_type)
-        {
-            TitleInfo *cur_info = title_info;
-            bool found = false;
-
-            while(cur_info)
-            {
-                if (cur_info->meta_key.type == entry->meta_type)
-                {
-                    title_info = cur_info;
-                    found = true;
-                    break;
-                }
-
-                cur_info = cur_info->next;
-            }
-
-            if (!found)
-            {
-                consolePrint("[%u/%u] missing expected type for %016lX\n", i + 1, g_nspDumpQueueCount, entry->title_id);
-                titleFreeTitleInfo(&title_info_root);
-                fail_count++;
-                continue;
-            }
-        }
+        TitleInfo *queue_title_info = g_nspDumpQueue[i];
 
         consoleClear();
         consolePrint("queued nsp dump %u/%u\n", i + 1, g_nspDumpQueueCount);
 
-        bool ret = saveNintendoSubmissionPackage(title_info);
-
-        titleFreeTitleInfo(&title_info_root);
-
-        if (ret)
+        if (saveNintendoSubmissionPackage(queue_title_info))
         {
             success_count++;
-
-            if (i < (g_nspDumpQueueCount - 1)) memmove(&(g_nspDumpQueue[i]), &(g_nspDumpQueue[i + 1]), (g_nspDumpQueueCount - i - 1) * sizeof(NspQueueEntry));
-
-            g_nspDumpQueueCount--;
-
-            if (!g_nspDumpQueueCount)
-            {
-                free(g_nspDumpQueue);
-                g_nspDumpQueue = NULL;
-                break;
-            }
-
-            NspQueueEntry *new_queue = realloc(g_nspDumpQueue, g_nspDumpQueueCount * sizeof(NspQueueEntry));
-            if (new_queue) g_nspDumpQueue = new_queue;
+            removeNspQueueEntryByIndex(i);
+            if (!g_nspDumpQueueCount) break;
         } else {
             fail_count++;
             i++;
         }
-
-        if (!g_appletStatus) break;
     }
 
     updateNspQueueViewList();
@@ -2514,9 +2647,7 @@ static bool clearNintendoSubmissionPackageQueue(void *userdata)
     u64 btn_down = utilsWaitForButtonPress(HidNpadButton_A | HidNpadButton_B);
     if (btn_down & HidNpadButton_A)
     {
-        free(g_nspDumpQueue);
-        g_nspDumpQueue = NULL;
-        g_nspDumpQueueCount = 0;
+        freeNspDumpQueue();
 
         freeNspQueueViewList();
 
@@ -2533,18 +2664,7 @@ static bool removeNintendoSubmissionPackageQueueEntry(void *userdata)
     u32 idx = *((u32*)userdata);
     if (idx >= g_nspDumpQueueCount) return false;
 
-    if (idx < (g_nspDumpQueueCount - 1)) memmove(&(g_nspDumpQueue[idx]), &(g_nspDumpQueue[idx + 1]), (g_nspDumpQueueCount - idx - 1) * sizeof(NspQueueEntry));
-
-    g_nspDumpQueueCount--;
-
-    if (!g_nspDumpQueueCount)
-    {
-        free(g_nspDumpQueue);
-        g_nspDumpQueue = NULL;
-    } else {
-        NspQueueEntry *new_queue = realloc(g_nspDumpQueue, g_nspDumpQueueCount * sizeof(NspQueueEntry));
-        if (new_queue) g_nspDumpQueue = new_queue;
-    }
+    removeNspQueueEntryByIndex(idx);
 
     updateNspQueueViewList();
 

--- a/code_templates/nxdt_rw_poc.c
+++ b/code_templates/nxdt_rw_poc.c
@@ -386,6 +386,7 @@ static MenuElement g_storageMenuElement = {
 static TitleInfo **g_nspDumpQueue = NULL;
 static u32 g_nspDumpQueueCount = 0;
 static u32 g_nspDumpQueueCapacity = 0;
+static bool g_lastNspDumpUserCancelled = false;
 
 static MenuElementOption g_nspSetDownloadDistributionMenuElementOption = {
     .selected = 0,
@@ -2499,6 +2500,7 @@ static bool startNintendoSubmissionPackageQueue(void *userdata)
     }
 
     u32 success_count = 0, fail_count = 0;
+    bool queue_cancelled = false;
 
     for(u32 i = 0; i < g_nspDumpQueueCount;)
     {
@@ -2514,12 +2516,25 @@ static bool startNintendoSubmissionPackageQueue(void *userdata)
             removeNspDumpQueueEntryByIndex(i);
             if (!g_nspDumpQueueCount) break;
         } else {
+            if (g_lastNspDumpUserCancelled)
+            {
+                queue_cancelled = true;
+                break;
+            }
+
             fail_count++;
             i++;
         }
     }
 
     updateNspQueueViewList();
+
+    if (queue_cancelled)
+    {
+        consolePrint("\nqueue cancelled by user\n");
+        consolePrint("completed: %u | failed: %u | remaining: %u\n", success_count, fail_count, g_nspDumpQueueCount);
+        return false;
+    }
 
     consolePrint("\nqueue done: %u succeeded, %u failed\n", success_count, fail_count);
 
@@ -4024,6 +4039,8 @@ static bool saveNintendoSubmissionPackage(void *userdata)
 {
     if (!userdata) return false;
 
+    g_lastNspDumpUserCancelled = false;
+
     TitleInfo *title_info = (TitleInfo*)userdata;
     TitleApplicationMetadata *app_metadata = title_info->app_metadata;
 
@@ -4139,6 +4156,7 @@ static bool saveNintendoSubmissionPackage(void *userdata)
     } else
     if (nsp_thread_data.transfer_cancelled)
     {
+        g_lastNspDumpUserCancelled = true;
         consolePrint("process cancelled\n");
     } else {
         start = (time(NULL) - start);

--- a/code_templates/nxdt_rw_poc.c
+++ b/code_templates/nxdt_rw_poc.c
@@ -1699,14 +1699,14 @@ int main(int argc, char *argv[])
             if (selected_element->task_func)
             {
                 bool show_button_prompt = true;
-                /* For queue management actions, we want to show the button prompt 
-                and wait for a button press before going back to the queue view, 
-                but we don't want to wait for USB or show the "please wait" message 
-                since these actions are usually very fast and waiting for USB or 
+                /* For queue management actions, we want to show the button prompt
+                and wait for a button press before going back to the queue view,
+                but we don't want to wait for USB or show the "please wait" message
+                since these actions are usually very fast and waiting for USB or
                 showing the message could be disruptive. */
-                bool is_queue_management_action = (selected_element->task_func == &addNintendoSubmissionPackageToQueue ||
-                                                   selected_element->task_func == &addAllAvailableNintendoSubmissionPackagesToQueue ||
-                                                   selected_element->task_func == &clearNintendoSubmissionPackageQueue ||
+                bool is_queue_management_action = (selected_element->task_func == &addNintendoSubmissionPackageToQueue || \
+                                                   selected_element->task_func == &addAllAvailableNintendoSubmissionPackagesToQueue || \
+                                                   selected_element->task_func == &clearNintendoSubmissionPackageQueue || \
                                                    selected_element->task_func == &removeNintendoSubmissionPackageQueueEntry);
 
                 consoleClear();
@@ -1730,22 +1730,29 @@ int main(int argc, char *argv[])
                 } else
                 if (cur_menu->id > MenuId_Root && !is_queue_management_action)
                 {
-                    /* Wait for USB session (if needed). */
-                    if (useUsbHost() && !waitForUsb())
+                    if (selected_element->task_func != &startNintendoSubmissionPackageQueue || (g_nspDumpQueueCount && g_nspDumpQueue))
                     {
-                        if (g_appletStatus) continue;
-                        break;
+                        /* Wait for USB session (if needed). */
+                        if (useUsbHost() && !waitForUsb())
+                        {
+                            if (g_appletStatus) continue;
+                            break;
+                        }
+
+                        /* Run task. */
+                        utilsSetLongRunningProcessState(true);
+
+                        if (selected_element->task_func(selected_element->userdata))
+                        {
+                            if (!useUsbHost()) updateStorageList(); // update free space
+                        }
+
+                        utilsSetLongRunningProcessState(false);
+                    } else {
+                        /* Don't proceed any further if there's no queue to work with. */
+                        /* There's no point in waiting for a USB connection if there's nothing to do afterwards. */
+                        consolePrint("nsp queue is empty\n");
                     }
-
-                    /* Run task. */
-                    utilsSetLongRunningProcessState(true);
-
-                    if (selected_element->task_func(selected_element->userdata))
-                    {
-                        if (!useUsbHost()) updateStorageList(); // update free space
-                    }
-
-                    utilsSetLongRunningProcessState(false);
                 } else {
                     /* Ignore result. */
                     selected_element->task_func(selected_element->userdata);
@@ -1759,7 +1766,7 @@ int main(int argc, char *argv[])
                 }
             }
         } else
-        if (((btn_down & HidNpadButton_Down) || (btn_held & (HidNpadButton_StickLDown | HidNpadButton_StickRDown))) && element_count)
+        if (((btn_down & HidNpadButton_Down) || (btn_held & HidNpadButton_StickLDown)) && element_count)
         {
             cur_menu->selected++;
 
@@ -1778,7 +1785,7 @@ int main(int argc, char *argv[])
                 cur_menu->scroll++;
             }
         } else
-        if (((btn_down & HidNpadButton_Up) || (btn_held & (HidNpadButton_StickLUp | HidNpadButton_StickRUp))) && element_count)
+        if (((btn_down & HidNpadButton_Up) || (btn_held & HidNpadButton_StickLUp)) && element_count)
         {
             cur_menu->selected--;
 
@@ -1796,6 +1803,18 @@ int main(int argc, char *argv[])
             {
                 cur_menu->scroll--;
             }
+        } else
+        if (((btn_down & (HidNpadButton_Right | HidNpadButton_StickLRight | HidNpadButton_StickRRight)) || (btn_held & HidNpadButton_StickRDown)) && element_count && !selected_element_options)
+        {
+            cur_menu->selected += page_size;
+            if (cur_menu->selected >= element_count) cur_menu->selected = (element_count - 1);
+            cur_menu->scroll = (cur_menu->selected - (cur_menu->selected % page_size));
+        } else
+        if (((btn_down & (HidNpadButton_Left | HidNpadButton_StickLLeft | HidNpadButton_StickRLeft)) || (btn_held & HidNpadButton_StickRUp)) && element_count && !selected_element_options)
+        {
+            cur_menu->selected -= page_size;
+            if (cur_menu->selected >= (UINT32_MAX - page_size) && cur_menu->selected <= UINT32_MAX) cur_menu->selected = 0;
+            cur_menu->scroll = (cur_menu->selected - (cur_menu->selected % page_size));
         } else
         if ((btn_down & (HidNpadButton_Right | HidNpadButton_StickLRight | HidNpadButton_StickRRight)) && selected_element_options)
         {

--- a/code_templates/nxdt_rw_poc.c
+++ b/code_templates/nxdt_rw_poc.c
@@ -2314,7 +2314,43 @@ static int nspDumpQueueViewListEntrySortFunction(const void *a, const void *b)
     const MenuElement *menu_element_1 = *((const MenuElement**)a);
     const MenuElement *menu_element_2 = *((const MenuElement**)b);
 
-    return strcasecmp(menu_element_1->str, menu_element_2->str);
+    const TitleInfo* title_info_1 = (const TitleInfo*)menu_element_1->userdata;
+    const TitleInfo* title_info_2 = (const TitleInfo*)menu_element_2->userdata;
+
+    if (title_info_1->app_metadata && title_info_2->app_metadata)
+    {
+        int ret = strcasecmp(title_info_1->app_metadata->name, title_info_2->app_metadata->name);
+        if (ret != 0) return ret;
+    }
+
+    if (title_info_1->meta_key.type < title_info_2->meta_key.type)
+    {
+        return -1;
+    } else
+    if (title_info_1->meta_key.type > title_info_2->meta_key.type)
+    {
+        return 1;
+    }
+
+    if (title_info_1->meta_key.id < title_info_2->meta_key.id)
+    {
+        return -1;
+    } else
+    if (title_info_1->meta_key.id > title_info_2->meta_key.id)
+    {
+        return 1;
+    }
+
+    if (title_info_1->version.value < title_info_2->version.value)
+    {
+        return -1;
+    } else
+    if (title_info_1->version.value > title_info_2->version.value)
+    {
+        return 1;
+    }
+
+    return 0;
 }
 
 static void removeNspDumpQueueViewListEntryByTitleInfoPtr(TitleInfo *title_info)

--- a/include/core/title.h
+++ b/include/core/title.h
@@ -124,8 +124,9 @@ TitleInfo *titleGetTitleInfoEntryFromStorageByTitleId(u8 storage_id, u64 title_i
 void titleFreeTitleInfo(TitleInfo **info);
 
 /// Returns a pointer to a dynamically allocated TitleInfo element that is a duplicate of the provided one. Returns NULL if an error occurs.
+/// If 'dup_linked_lists' is true, the internal linked lists will be duplicated as well. Otherwise, their pointers will be set to NULL.
 /// Use titleFreeTitleInfo() to free the returned data.
-TitleInfo *titleDuplicateTitleInfoEntry(const TitleInfo *title_info);
+TitleInfo *titleDuplicateTitleInfo(const TitleInfo *title_info, bool dup_linked_lists);
 
 /// Populates a TitleUserApplicationData element with dynamically allocated data using a user application ID.
 /// Use titleFreeUserApplicationData() to free the populated data.
@@ -158,7 +159,7 @@ void titleFreeOrphanTitles(TitleInfo ***orphan_info);
 bool titleIsGameCardInfoUpdated(void);
 
 /// Returns a pointer to a dynamically allocated buffer that holds a filename string suitable for output title dumps. Returns NULL if an error occurs.
-char *titleGenerateFileName(TitleInfo *title_info, TitleNamingConvention naming_convention, TitleFileNameIllegalCharReplaceType illegal_char_replace_type);
+char *titleGenerateFileName(const TitleInfo *title_info, TitleNamingConvention naming_convention, TitleFileNameIllegalCharReplaceType illegal_char_replace_type);
 
 /// Returns a pointer to a dynamically allocated buffer that holds a filename string suitable for output gamecard dumps. Returns NULL if an error occurs.
 /// A valid gamecard must be inserted, and title info must have been loaded from it accordingly.
@@ -318,7 +319,7 @@ NX_INLINE u32 titleGetContentCountByType(TitleInfo *info, u8 content_type)
     return cnt;
 }
 
-NX_INLINE NcmContentInfo *titleGetContentInfoByTypeAndIdOffset(TitleInfo *info, u8 content_type, u8 id_offset)
+NX_INLINE NcmContentInfo *titleGetContentInfoByTypeAndIdOffset(const TitleInfo *info, u8 content_type, u8 id_offset)
 {
     if (!info || !info->content_count || !info->content_infos || content_type > NcmContentType_DeltaFragment) return NULL;
 
@@ -331,7 +332,7 @@ NX_INLINE NcmContentInfo *titleGetContentInfoByTypeAndIdOffset(TitleInfo *info, 
     return NULL;
 }
 
-NX_INLINE u32 titleGetCountFromInfoBlock(TitleInfo *title_info)
+NX_INLINE u32 titleGetCountFromInfoBlock(const TitleInfo *title_info)
 {
     if (!title_info) return 0;
 

--- a/include/core/title.h
+++ b/include/core/title.h
@@ -124,6 +124,7 @@ TitleInfo *titleGetTitleInfoEntryFromStorageByTitleId(u8 storage_id, u64 title_i
 void titleFreeTitleInfo(TitleInfo **info);
 
 /// Returns a pointer to a dynamically allocated TitleInfo element that is a duplicate of the provided one. Returns NULL if an error occurs.
+/// Use titleFreeTitleInfo() to free the returned data.
 TitleInfo *titleDuplicateTitleInfoEntry(const TitleInfo *title_info);
 
 /// Populates a TitleUserApplicationData element with dynamically allocated data using a user application ID.

--- a/include/core/title.h
+++ b/include/core/title.h
@@ -123,6 +123,9 @@ TitleInfo *titleGetTitleInfoEntryFromStorageByTitleId(u8 storage_id, u64 title_i
 /// Frees a dynamically allocated TitleInfo element.
 void titleFreeTitleInfo(TitleInfo **info);
 
+/// Returns a pointer to a dynamically allocated TitleInfo element that is a duplicate of the provided one. Returns NULL if an error occurs.
+TitleInfo *titleDuplicateTitleInfoEntry(const TitleInfo *title_info);
+
 /// Populates a TitleUserApplicationData element with dynamically allocated data using a user application ID.
 /// Use titleFreeUserApplicationData() to free the populated data.
 bool titleGetUserApplicationData(u64 app_id, TitleUserApplicationData *out);

--- a/source/core/title.c
+++ b/source/core/title.c
@@ -869,6 +869,20 @@ void titleFreeTitleInfo(TitleInfo **info)
     *info = NULL;
 }
 
+TitleInfo *titleDuplicateTitleInfoEntry(const TitleInfo *title_info)
+{
+    if (!title_info || !titleIsValidInfoBlock(title_info)) return NULL;
+
+    TitleInfo *ret = NULL;
+
+    SCOPED_LOCK(&g_titleMutex)
+    {
+        ret = titleDuplicateTitleInfo((TitleInfo*)title_info);
+    }
+
+    return ret;
+}
+
 bool titleGetUserApplicationData(u64 app_id, TitleUserApplicationData *out)
 {
     bool ret = false;

--- a/source/core/title.c
+++ b/source/core/title.c
@@ -614,7 +614,7 @@ static TitleInfo *titleGetLatestAvailablePatchForUserTitle(u8 storage_id, const 
 static bool _titleGetUserApplicationData(u64 app_id, TitleUserApplicationData *out);
 
 static TitleInfo *titleDuplicateTitleInfoFull(TitleInfo *title_info, TitleInfo *previous, TitleInfo *next);
-static TitleInfo *titleDuplicateTitleInfo(TitleInfo *title_info);
+static TitleInfo *_titleDuplicateTitleInfo(TitleInfo *title_info);
 
 static char *titleGetDisplayVersionString(TitleInfo *title_info);
 
@@ -877,7 +877,7 @@ TitleInfo *titleDuplicateTitleInfoEntry(const TitleInfo *title_info)
 
     SCOPED_LOCK(&g_titleMutex)
     {
-        ret = titleDuplicateTitleInfo((TitleInfo*)title_info);
+        ret = _titleDuplicateTitleInfo((TitleInfo*)title_info);
     }
 
     return ret;
@@ -980,7 +980,7 @@ TitleInfo *titleGetAddOnContentBaseOrPatchList(TitleInfo *title_info)
             }
 
             /* Duplicate current entry. */
-            tmp = titleDuplicateTitleInfo(aoc_info);
+            tmp = _titleDuplicateTitleInfo(aoc_info);
             if (!tmp)
             {
                 LOG_MSG_ERROR("Failed to duplicate TitleInfo object!");
@@ -3225,7 +3225,7 @@ static TitleInfo *titleDuplicateTitleInfoFull(TitleInfo *title_info, TitleInfo *
     bool dup_previous = false, dup_next = false, success = false;
 
     /* Duplicate TitleInfo object. */
-    title_info_dup = titleDuplicateTitleInfo(title_info);
+    title_info_dup = _titleDuplicateTitleInfo(title_info);
     if (!title_info_dup)
     {
         LOG_MSG_ERROR("Failed to duplicate TitleInfo object!");
@@ -3290,7 +3290,7 @@ end:
     return title_info_dup;
 }
 
-static TitleInfo *titleDuplicateTitleInfo(TitleInfo *title_info)
+static TitleInfo *_titleDuplicateTitleInfo(TitleInfo *title_info)
 {
     if (!titleIsValidInfoBlock(title_info))
     {

--- a/source/core/title.c
+++ b/source/core/title.c
@@ -613,10 +613,10 @@ static TitleInfo *titleGetLatestAvailablePatchForUserTitle(u8 storage_id, const 
 
 static bool _titleGetUserApplicationData(u64 app_id, TitleUserApplicationData *out);
 
-static TitleInfo *titleDuplicateTitleInfoFull(TitleInfo *title_info, TitleInfo *previous, TitleInfo *next);
-static TitleInfo *_titleDuplicateTitleInfo(TitleInfo *title_info);
+static TitleInfo *titleDuplicateTitleInfoFull(const TitleInfo *title_info, TitleInfo *previous, TitleInfo *next);
+static TitleInfo *_titleDuplicateTitleInfo(const TitleInfo *title_info);
 
-static char *titleGetDisplayVersionString(TitleInfo *title_info);
+static char *titleGetDisplayVersionString(const TitleInfo *title_info);
 
 static bool titleCreateGameCardInfoThread(void);
 static void titleDestroyGameCardInfoThread(void);
@@ -869,18 +869,9 @@ void titleFreeTitleInfo(TitleInfo **info)
     *info = NULL;
 }
 
-TitleInfo *titleDuplicateTitleInfoEntry(const TitleInfo *title_info)
+TitleInfo *titleDuplicateTitleInfo(const TitleInfo *title_info, bool dup_linked_lists)
 {
-    if (!title_info || !titleIsValidInfoBlock(title_info)) return NULL;
-
-    TitleInfo *ret = NULL;
-
-    SCOPED_LOCK(&g_titleMutex)
-    {
-        ret = _titleDuplicateTitleInfo((TitleInfo*)title_info);
-    }
-
-    return ret;
+    return (dup_linked_lists ? titleDuplicateTitleInfoFull(title_info, NULL, NULL) : _titleDuplicateTitleInfo(title_info));
 }
 
 bool titleGetUserApplicationData(u64 app_id, TitleUserApplicationData *out)
@@ -1090,7 +1081,7 @@ bool titleIsGameCardInfoUpdated(void)
     return ret;
 }
 
-char *titleGenerateFileName(TitleInfo *title_info, TitleNamingConvention naming_convention, TitleFileNameIllegalCharReplaceType illegal_char_replace_type)
+char *titleGenerateFileName(const TitleInfo *title_info, TitleNamingConvention naming_convention, TitleFileNameIllegalCharReplaceType illegal_char_replace_type)
 {
     if (!titleIsValidInfoBlock(title_info) || naming_convention >= TitleNamingConvention_Count || illegal_char_replace_type >= TitleFileNameIllegalCharReplaceType_Count)
     {
@@ -3213,7 +3204,7 @@ static bool _titleGetUserApplicationData(u64 app_id, TitleUserApplicationData *o
     return ret;
 }
 
-static TitleInfo *titleDuplicateTitleInfoFull(TitleInfo *title_info, TitleInfo *previous, TitleInfo *next)
+static TitleInfo *titleDuplicateTitleInfoFull(const TitleInfo *title_info, TitleInfo *previous, TitleInfo *next)
 {
     if (!titleIsValidInfoBlock(title_info))
     {
@@ -3290,7 +3281,7 @@ end:
     return title_info_dup;
 }
 
-static TitleInfo *_titleDuplicateTitleInfo(TitleInfo *title_info)
+static TitleInfo *_titleDuplicateTitleInfo(const TitleInfo *title_info)
 {
     if (!titleIsValidInfoBlock(title_info))
     {
@@ -3346,7 +3337,7 @@ end:
     return title_info_dup;
 }
 
-static char *titleGetDisplayVersionString(TitleInfo *title_info)
+static char *titleGetDisplayVersionString(const TitleInfo *title_info)
 {
     NcmContentInfo *nacp_content = NULL;
 


### PR DESCRIPTION
Provided by @Dimensional.

Creates an internal NSP queue using dynamically allocated `TitleInfo*` pointers to keep track of the individual titles to dump.

Needs further revising and testing.