### PR TITLE
Replace illegal characters in filenames by lookalikes insted of underscore

### DIFF
--- a/include/core/nxdt_utils.h
+++ b/include/core/nxdt_utils.h
@@ -127,6 +127,17 @@ void utilsJoinThread(Thread *thread);
 /// If the buffer isn't big enough to hold both its current contents and the new formatted string, it will be resized.
 __attribute__((format(printf, 3, 4))) bool utilsAppendFormattedStringToBuffer(char **dst, size_t *dst_size, const char *fmt, ...);
 
+/// Replaces illegal filesystem unicode codepoint with valid lookalike.
+/// Returns 0 if codepoint is valid.
+u32 utilsIllegalLookalikeCodepoint(u32 code);
+
+/// Replaces illegal filesystem characters in the provided NULL-terminated UTF-8 string with valid lookalikes.
+/// Replacements are performed on a per-codepoint basis, which means the string size in bytes can be vary with this function.
+/// If an invalid UTF-8 character is found, it will be replaced by '\uFFFD' (Unicode Replacement Character).
+/// Under normal operation, the string will remain the same size, or worst case, grow upto 21 bytes.
+/// The maximum size the string can become is strlen * 4.
+void utilsReplaceIllegalCharactersWithLookalike(char *str);
+
 /// Replaces illegal filesystem characters in the provided NULL-terminated UTF-8 string with underscores ('_').
 /// If 'ascii_only' is set to true, all codepoints outside of the [0x20,0x7E] range will also be replaced with underscores.
 /// Replacements are performed on a per-codepoint basis, which means the string size in bytes can be reduced by this function.

--- a/include/core/title.h
+++ b/include/core/title.h
@@ -89,7 +89,8 @@ typedef enum : u8 {
     TitleFileNameIllegalCharReplaceType_None               = 0,
     TitleFileNameIllegalCharReplaceType_IllegalFsChars     = 1,
     TitleFileNameIllegalCharReplaceType_KeepAsciiCharsOnly = 2,
-    TitleFileNameIllegalCharReplaceType_Count              = 3  ///< Total values supported by this enum.
+    TitleFileNameIllegalCharReplaceType_IllegalLookalike   = 3,
+    TitleFileNameIllegalCharReplaceType_Count              = 4  ///< Total values supported by this enum.
 } TitleFileNameIllegalCharReplaceType;
 
 /// Initializes the title interface.

--- a/source/core/nxdt_utils.c
+++ b/source/core/nxdt_utils.c
@@ -577,6 +577,94 @@ end:
     return success;
 }
 
+u32 utilsIllegalLookalikeCodepoint(u32 code) {
+    switch (code) {
+        /* Remap control characters to Control Pictures */
+        case /* NUL */ 0x00: return 0x2400;
+        case /* SOH */ 0x01: return 0x2401;
+        case /* STX */ 0x02: return 0x2402;
+        case /* ETX */ 0x03: return 0x2403;
+        case /* EOT */ 0x04: return 0x2404;
+        case /* ENQ */ 0x05: return 0x2405;
+        case /* ACK */ 0x06: return 0x2406;
+        case /* BEL */ 0x07: return 0x2407;
+        case /* BS  */ 0x08: return 0x2408;
+        case /* HT  */ 0x09: return 0x2409;
+        case /* LF  */ 0x0A: return 0x240A;
+        case /* VT  */ 0x0B: return 0x240B;
+        case /* FF  */ 0x0C: return 0x240C;
+        case /* CR  */ 0x0D: return 0x240D;
+        case /* SO  */ 0x0E: return 0x240E;
+        case /* SI  */ 0x0F: return 0x240F;
+        case /* DLE */ 0x10: return 0x2410;
+        case /* DC1 */ 0x11: return 0x2411;
+        case /* DC2 */ 0x12: return 0x2412;
+        case /* DC3 */ 0x13: return 0x2413;
+        case /* DC4 */ 0x14: return 0x2414;
+        case /* NAK */ 0x15: return 0x2415;
+        case /* SYN */ 0x16: return 0x2416;
+        case /* ETB */ 0x17: return 0x2417;
+        case /* CAN */ 0x18: return 0x2418;
+        case /* EM  */ 0x19: return 0x2419;
+        case /* SUB */ 0x1A: return 0x241A;
+        case /* ESC */ 0x1B: return 0x241B;
+        case /* FS  */ 0x1C: return 0x241C;
+        case /* GS  */ 0x1D: return 0x241D;
+        case /* RS  */ 0x1E: return 0x241E;
+        case /* US  */ 0x1F: return 0x241F;
+        case /* DEL */ 0x7F: return 0x2421;
+
+        /* Remap graphic characters to Halfwidth and Fullwidth Forms */
+        case /* "   */ 0x22: return 0xFF02;
+        case /* *   */ 0x2A: return 0xFF0A;
+        case /* /   */ 0x2F: return 0xFF0F;
+        case /* :   */ 0x3A: return 0xFF1A;
+        case /* <   */ 0x3C: return 0xFF1C;
+        case /* >   */ 0x3E: return 0xFF1E;
+        case /* ?   */ 0x3F: return 0xFF1F;
+        case /* \   */ 0x5C: return 0xFF3C;
+        case /* |   */ 0x7C: return 0xFF5C;
+    }
+
+    return 0;
+}
+
+void utilsReplaceIllegalCharactersWithLookalike(char *str)
+{
+    size_t str_size = 0, cur_pos = 0;
+
+    if (!str || !(str_size = strlen(str))) return;
+
+    u32 src, dst, tmp;
+    ssize_t src_size, dst_size;
+    u8 *ptr = (u8*)str;
+
+    while(cur_pos < str_size)
+    {
+        /* Decode codepoint */
+        src_size = decode_utf8(&src, ptr);
+        if (src_size < 0) { src_size = 1; src = /* REP */ 0xFFFE; }
+
+        /* Remap codepoint */
+        dst = utilsIllegalLookalikeCodepoint(src);
+        dst = dst != 0 ? dst : src;
+
+        /* Encode codepoint */
+        dst_size = encode_utf8((u8*)&tmp, dst);
+        if (dst_size < 0) dst_size = encode_utf8((u8*)&tmp, /* REP */ 0xFFFE);
+
+        /* Replace character */
+        memmove(ptr + dst_size, ptr + src_size, str_size - cur_pos);
+        memmove(ptr, &tmp, dst_size);
+
+        ptr += dst_size;
+        cur_pos += (size_t)dst_size;
+        str_size += (size_t)(dst_size - src_size);
+    }
+
+    *ptr = '\0';
+}
+
 void utilsReplaceIllegalCharacters(char *str, bool ascii_only)
 {
     size_t str_size = 0, cur_pos = 0;

--- a/source/core/title.c
+++ b/source/core/title.c
@@ -1110,8 +1110,6 @@ char *titleGenerateFileName(const TitleInfo *title_info, TitleNamingConvention n
                 snprintf(title_name + title_name_len, MAX_ELEMENTS(title_name) - title_name_len, "%s ", version_str);
                 free(version_str);
             }
-
-            if (illegal_char_replace_type) utilsReplaceIllegalCharacters(title_name, illegal_char_replace_type == TitleFileNameIllegalCharReplaceType_KeepAsciiCharsOnly);
         }
 
         title_name_len = strlen(title_name);
@@ -1121,6 +1119,20 @@ char *titleGenerateFileName(const TitleInfo *title_info, TitleNamingConvention n
     if (naming_convention == TitleNamingConvention_IdAndVersionOnly)
     {
         snprintf(title_name, MAX_ELEMENTS(title_name), "%016lX_v%u_%s", title_info->meta_key.id, title_info->meta_key.version, g_filenameTypeStrings[type_idx]);
+    }
+
+    /* Replace illegal characters in filename. */
+    if (illegal_char_replace_type == TitleFileNameIllegalCharReplaceType_KeepAsciiCharsOnly)
+    {
+        utilsReplaceIllegalCharacters(title_name, true);
+    }
+    if (illegal_char_replace_type == TitleFileNameIllegalCharReplaceType_IllegalFsChars)
+    {
+        utilsReplaceIllegalCharacters(title_name, false);
+    }
+    if (illegal_char_replace_type == TitleFileNameIllegalCharReplaceType_IllegalLookalike)
+    {
+        utilsReplaceIllegalCharactersWithLookalike(title_name);
     }
 
     /* Duplicate generated filename. */


### PR DESCRIPTION
After dumping some titles and parts of them becoming underscores, due to Windows limitations, I thought there had to be a better way of preserving them. So after remembering how rclone handles restricted characters syncs across FS, I thought I could implement something similar here.

The trick here is to replace illegal characters with unicode lookalikes, specifically their fullwidth variants, that way the user get to keep the original title, and Windows is happy.

As a bonus, when dumping via USB, as host apps are FS aware, they can optionally revert the escaping and keep the original title as-is, if the FS permits it.