### PR TITLE
fix: correct 'ocurred' to 'occurred' typo in USB error message

### DIFF
--- a/host/nxdt_host.py
+++ b/host/nxdt_host.py
@@ -688,7 +688,7 @@ def usbGetDeviceEndpoints() -> bool:
             if not g_cliMode:
                 utilsLogException(traceback.format_exc())
 
-            g_logger.error('Fatal error ocurred while enumerating USB devices.')
+            g_logger.error('Fatal error occurred while enumerating USB devices.')
 
             if g_isWindows:
                 g_logger.error('Try reinstalling the libusbK driver using Zadig.')


### PR DESCRIPTION
## Summary
Corrects a typo in the user-facing error message shown when USB device enumeration fails.

**Before:** `g_logger.error('Fatal error ocurred while enumerating USB devices.')`
**After:**  `g_logger.error('Fatal error occurred while enumerating USB devices.')`

## Change
- File: `host/nxdt_host.py` line 691
- Fix: `ocurred` → `occurred`
- Type: typo fix (user-facing error message)
- Commit email: 166608075+Jah-yee@users.noreply.github.com (GH007 compliant)

## Testing
Verified locally that the typo exists at line 691 and the fix is a minimal one-word correction.

---
*Submitted via automated PR workflow*