### PR TITLE
Update comments

### DIFF
--- a/include/core/nso.h
+++ b/include/core/nso.h
@@ -36,9 +36,9 @@ extern "C" {
 
 typedef enum : u32 {
     NsoFlags_None               = 0,
-    NsoFlags_TextCompress       = BIT(0),    ///< Determines if .text segment is LZ4-compressed.
-    NsoFlags_RoCompress         = BIT(1),    ///< Determines if .rodata segment is LZ4-compressed.
-    NsoFlags_DataCompress       = BIT(2),    ///< Determines if .data segment is LZ4-compressed.
+    NsoFlags_TextCompress       = BIT(0),    ///< Determines if .text segment is compressed.
+    NsoFlags_RoCompress         = BIT(1),    ///< Determines if .rodata segment is compressed.
+    NsoFlags_DataCompress       = BIT(2),    ///< Determines if .data segment is compressed.
     NsoFlags_TextHash           = BIT(3),    ///< Determines if .text segment hash must be checked during load.
     NsoFlags_RoHash             = BIT(4),    ///< Determines if .rodata segment hash must be checked during load.
     NsoFlags_DataHash           = BIT(5),    ///< Determines if .data segment hash must be checked during load.


### PR DESCRIPTION
When I was searching something, i found those comments that are wrong.

As a proof, you can check that any ZBIC compressed NSO should have 0xBF set in flags